### PR TITLE
Add `paddle.scale` Tests

### DIFF
--- a/test_scale/test_scale_develop.py
+++ b/test_scale/test_scale_develop.py
@@ -57,8 +57,8 @@ class TestScaleDevelopCase1_FP32(unittest.TestCase):
         np_inputs_array = np.load(self.np_input_dir)
         # get np array from npz file
         self.np_x = np_inputs_array["x"]
-        self.np_scale = np_inputs_array["scale"]
-        self.np_bias = np_inputs_array["bias"]
+        self.np_scale = float(np_inputs_array["scale"])
+        self.np_bias = float(np_inputs_array["bias"])
         self.np_dout = np_inputs_array["dout"]
         # convert np array dtype
         if self.dtype == "float16":

--- a/test_scale/test_scale_develop.py
+++ b/test_scale/test_scale_develop.py
@@ -58,7 +58,7 @@ class TestScaleDevelopCase1_FP32(unittest.TestCase):
         # get np array from npz file
         self.np_x = np_inputs_array["x"]
         self.np_scale = np_inputs_array["scale"]
-        self.np_bias = np_inputs_array("bias")
+        self.np_bias = np_inputs_array["bias"]
         self.np_dout = np_inputs_array["dout"]
         # convert np array dtype
         if self.dtype == "float16":

--- a/test_scale/test_scale_develop.py
+++ b/test_scale/test_scale_develop.py
@@ -124,6 +124,8 @@ class TestScaleDevelopCase1_FP32(unittest.TestCase):
         if self.dtype == "bfloat16":
             x = x.to(dtype=torch.bfloat16)
             dout = dout.to(dtype=torch.bfloat16)
+        scale = torch.tensor(scale, dtype=convert_dtype_to_torch_type(self.dtype))
+        bias = torch.tensor(bias, dtype=convert_dtype_to_torch_type(self.dtype))
         if bias_after_scale:
             out = x * scale + bias
         else:
@@ -131,6 +133,7 @@ class TestScaleDevelopCase1_FP32(unittest.TestCase):
         out_grads = torch.autograd.grad([out], [x], grad_outputs=[dout])
         if self.dtype == "bfloat16":
             out = out.to(dtype=torch.float32)
+            out_grads = map_structure(lambda x: x.to(dtype=torch.float32), out_grads)
         return out, out_grads
 
     def cal_eager_res(self, x, scale, bias, bias_after_scale, dout):
@@ -143,6 +146,7 @@ class TestScaleDevelopCase1_FP32(unittest.TestCase):
         )
         if self.dtype == "bfloat16":
             out = paddle.cast(out, dtype="float32")
+            out_grads = map_structure(lambda x: paddle.cast(x, dtype='float32'), out_grads)
         return out, out_grads
 
     def cal_static_res(self, x, scale, bias, bias_after_scale, dout):
@@ -155,6 +159,7 @@ class TestScaleDevelopCase1_FP32(unittest.TestCase):
         )
         if self.dtype == "bfloat16":
             out = paddle.cast(out, dtype="float32")
+            out_grads = map_structure(lambda x: paddle.cast(x, dtype='float32'), out_grads)
         return out, out_grads
 
     def test_eager_accuracy(self):

--- a/test_scale/test_scale_develop.py
+++ b/test_scale/test_scale_develop.py
@@ -1,0 +1,378 @@
+import numpy as np
+import paddle
+import torch
+import unittest
+from paddle.utils import map_structure
+import sys
+sys.path.append("..")
+from utils import TOLERANCE, convert_dtype_to_torch_type
+
+
+def generate_np_inputs_and_dout():
+    x_case1 = np.random.random(size=[1, 4096, 4096]).astype("float32")
+    scale_case1 = 10000.0
+    bias_case1 = -1.0
+    dout_case1 = np.random.random(size=[1, 4096, 4096]).astype("float32")
+
+    x_case2 = np.random.random(size=[1, 32, 4096, 192]).astype("float32")
+    scale_case2 = 0.07216878364870322
+    bias_case2 = 0.0
+    dout_case2 = np.random.random(size=[1, 32, 4096, 192]).astype("float32")
+
+    np.savez("./inputs_case1.npz", x=x_case1, scale=scale_case1, bias=bias_case1, dout = dout_case1)
+    np.savez("./inputs_case2.npz", x=x_case2, scale=scale_case2, bias=bias_case2, dout = dout_case2)
+
+
+class TestScaleDevelopCase1_FP32(unittest.TestCase):
+    def setUp(self):
+        self.init_params()
+        self.init_threshold()
+        self.init_np_inputs_and_dout()
+        x_torch, scale_torch, bias_torch, dout_torch = self.gen_torch_inputs_and_dout()
+        out_torch, out_grads_torch = self.cal_torch_res(x_torch, scale_torch, bias_torch, self.bias_after_scale, dout_torch)
+        del x_torch 
+        del scale_torch
+        del bias_torch
+        del dout_torch 
+        self.out_torch = out_torch.cpu().detach().numpy()
+        self.out_grads_torch = map_structure(
+                                lambda x: x.cpu().numpy(),
+                                out_grads_torch,
+                            )
+        del out_torch, out_grads_torch
+        torch.cuda.empty_cache()
+
+    def init_params(self):
+        self.np_input_dir = "./inputs_case1.npz"
+        self.dtype = "float32"
+        self.bias_after_scale = False
+        self.save_static_res_path = "./static_develop_res_case1_fp32.npz"
+        self.save_eager_res_path = "./eager_develop_res_case1_fp32.npz"
+    
+    def init_threshold(self):
+        self.atol = TOLERANCE[self.dtype]["atol"]
+        self.rtol = TOLERANCE[self.dtype]["rtol"]
+
+    def init_np_inputs_and_dout(self):
+        np_inputs_array = np.load(self.np_input_dir)
+        # get np array from npz file
+        self.np_x = np_inputs_array["x"]
+        self.np_scale = np_inputs_array["scale"]
+        self.np_bias = np_inputs_array("bias")
+        self.np_dout = np_inputs_array["dout"]
+        # convert np array dtype
+        if self.dtype == "float16":
+            self.np_x = self.np_x.astype("float16")
+            self.np_dout = self.np_dout.astype("float16")
+    
+    def gen_torch_inputs_and_dout(self):
+        x_torch = torch.tensor(
+            self.np_x,
+            device='cuda',
+            dtype=convert_dtype_to_torch_type(self.dtype)
+            if self.dtype != 'bfloat16'
+            else torch.float32,
+            requires_grad=True,
+        )
+        scale_torch = self.np_scale
+        bias_torch = self.np_bias
+        dout_torch = torch.tensor(
+            self.np_dout,
+            device='cuda',
+            dtype=convert_dtype_to_torch_type(self.dtype)
+            if self.dtype != 'bfloat16'
+            else torch.float32,
+            requires_grad=True,
+        )
+        return x_torch, scale_torch, bias_torch, dout_torch
+    
+    def gen_eager_inputs_and_dout(self):
+        x_eager = paddle.to_tensor(
+            self.np_x,
+            dtype=self.dtype if self.dtype != 'bfloat16' else "float32",
+            place="gpu",
+        )
+        x_eager.stop_gradient = False
+        scale_eager = self.np_scale
+        bias_eager = self.np_bias
+        dout_eager = paddle.to_tensor(
+            self.np_dout,
+            dtype=self.dtype if self.dtype != 'bfloat16' else "float32",
+            place="gpu",
+        )
+        dout_eager.stop_gradient = False
+        return x_eager, scale_eager, bias_eager, dout_eager
+
+    def gen_static_inputs_and_dout(self):
+        x_static = paddle.static.data(
+            'x',
+            shape=self.np_x.shape,
+            dtype=self.dtype if self.dtype != "bfloat16" else "float32",
+        )
+        x_static.stop_gradient = False
+        scale_static = self.np_scale
+        bias_static = self.np_bias
+        dout_static = paddle.static.data(
+            'dout',
+            shape=self.np_dout.shape,
+            dtype=self.dtype if self.dtype != "bfloat16" else "float32",
+        )
+        dout_static.stop_gradient = False
+        return x_static, scale_static, bias_static, dout_static
+
+    def cal_torch_res(self, x, scale, bias, bias_after_scale, dout):
+        if self.dtype == "bfloat16":
+            x = x.to(dtype=torch.bfloat16)
+            dout = dout.to(dtype=torch.bfloat16)
+        if bias_after_scale:
+            out = x * scale + bias
+        else:
+            out = scale * (x + bias)
+        out_grads = torch.autograd.grad([out], [x], grad_outputs=[dout])
+        if self.dtype == "bfloat16":
+            out = out.to(dtype=torch.float32)
+        return out, out_grads
+
+    def cal_eager_res(self, x, scale, bias, bias_after_scale, dout):
+        if self.dtype == "bfloat16":
+            x = paddle.cast(x, dtype="uint16")
+            dout = paddle.cast(dout, dtype="uint16")
+        out = paddle.scale(x, scale, bias, bias_after_scale)
+        out_grads = paddle.grad(
+            [out], [x], grad_outputs=[dout]
+        )
+        if self.dtype == "bfloat16":
+            out = paddle.cast(out, dtype="float32")
+        return out, out_grads
+
+    def cal_static_res(self, x, scale, bias, bias_after_scale, dout):
+        if self.dtype == "bfloat16":
+            x = paddle.cast(x, dtype="uint16")
+            dout = paddle.cast(dout, dtype="uint16")
+        out = paddle.scale(x, scale, bias, bias_after_scale)
+        out_grads = paddle.static.gradients(
+            [out], [x], target_gradients=[dout]
+        )
+        if self.dtype == "bfloat16":
+            out = paddle.cast(out, dtype="float32")
+        return out, out_grads
+
+    def test_eager_accuracy(self):
+        x_eager, scale_eager, bias_eager, dout_eager = self.gen_eager_inputs_and_dout()
+        print(paddle.device.cuda.memory_allocated(paddle.CUDAPlace(0)))
+
+        out_eager, out_grads_eager = self.cal_eager_res(x_eager, scale_eager, bias_eager, self.bias_after_scale, dout_eager)
+        del x_eager
+        del scale_eager
+        del bias_eager
+        del dout_eager
+        print(paddle.device.cuda.memory_allocated(paddle.CUDAPlace(0)))
+        out_eager = out_eager.numpy()
+        out_grads_eager = map_structure(
+                                lambda x: x.numpy(),
+                                out_grads_eager,
+                            )
+        # save eager res for test_scale_incubate
+        np.savez(self.save_eager_res_path, out_eager=out_eager, out_grads_eager_0=out_grads_eager[0])
+        
+        # compare eager res with torch
+        np.testing.assert_allclose(
+            out_eager,
+            self.out_torch,
+            self.atol,
+            self.rtol,
+            err_msg=(
+                'Develop: compare scale eager forward res with torch failed in %s dtype'
+            )
+            % self.dtype,
+        )
+        for idx in range(len(out_grads_eager)):
+            np.testing.assert_allclose(
+                out_grads_eager[idx],
+                self.out_grads_torch[idx],
+                self.atol,
+                self.rtol,
+                err_msg=(
+                    'Develop: compare scale eager grad res with torch failed in %s dtype'
+                )
+                % self.dtype,
+            )
+    
+    def test_static_accuracy(self):
+        with paddle.fluid.framework._dygraph_guard(None):
+            mp, sp = paddle.static.Program(), paddle.static.Program()
+            with paddle.static.program_guard(mp, sp):
+                x_static, scale_static, bias_static, dout_static = self.gen_static_inputs_and_dout()
+                (out_static, out_grads_static) = self.cal_static_res(
+                    x_static,
+                    scale_static,
+                    bias_static,
+                    self.bias_after_scale,
+                    dout_static,
+            )
+            exe = paddle.static.Executor(
+                place=paddle.CUDAPlace(0)
+            )
+            exe.run(sp)
+            out = exe.run(
+                mp,
+                feed={"x": self.np_x, "dout": self.np_dout},
+                fetch_list=[out_static] + out_grads_static,
+            )
+            out_static, out_grads_static = out[0], out[1:]
+
+        # save static res for test_scale_incubate
+        np.savez(self.save_static_res_path, out_static=out_static, out_grads_static_0=out_grads_static[0])
+        
+        # compare static res with torch
+        np.testing.assert_allclose(
+            out_static,
+            self.out_torch,
+            self.atol,
+            self.rtol,
+            err_msg=(
+                'Develop: compare scale static forward res with torch failed in %s dtype'
+            )
+            % self.dtype,
+        )
+        for idx in range(len(out_grads_static)):
+            np.testing.assert_allclose(
+                out_grads_static[idx],
+                self.out_grads_torch[idx],
+                self.atol,
+                self.rtol,
+                err_msg=(
+                    'Develop: compare scale static grad res with torch failed in %s dtype'
+                )
+                % self.dtype,
+            )
+
+    def test_eager_stability(self):
+        x_eager, scale_eager, bias_eager, dout_eager = self.gen_eager_inputs_and_dout()
+        out_eager_baseline, out_grads_eager_baseline = self.cal_eager_res(x_eager, scale_eager, bias_eager, self.bias_after_scale, dout_eager)
+        out_eager_baseline = out_eager_baseline.numpy()
+        out_grads_eager_baseline = map_structure(
+                                lambda x: x.numpy(),
+                                out_grads_eager_baseline,
+                            )
+        for i in range(50):
+            out_eager, out_grads_eager = self.cal_eager_res(x_eager, scale_eager, bias_eager, self.bias_after_scale, dout_eager)
+            out_eager = out_eager.numpy()
+            out_grads_eager = map_structure(
+                                    lambda x: x.numpy(),
+                                    out_grads_eager,
+                                )
+            np.testing.assert_equal(
+                out_eager,
+                out_eager_baseline,
+                err_msg=(
+                    'Develop: paddle.scale eager forward is unstable in %s dtype'
+                )
+                % self.dtype,
+            )
+            for idx in range(len(out_grads_eager)):
+                np.testing.assert_equal(
+                    out_grads_eager[idx],
+                    out_grads_eager_baseline[idx],
+                    err_msg=(
+                        'Develop: paddle.scale eager grad is unstable in %s dtype'
+                    )
+                    % self.dtype,
+                )
+
+    def test_static_stability(self):
+        with paddle.fluid.framework._dygraph_guard(None):
+            mp, sp = paddle.static.Program(), paddle.static.Program()
+            with paddle.static.program_guard(mp, sp):
+                x_static, scale_static, bias_static, dout_static = self.gen_static_inputs_and_dout()
+                (out_static_pg, out_grads_static_pg) = self.cal_static_res(
+                    x_static,
+                    scale_static,
+                    bias_static,
+                    self.bias_after_scale,
+                    dout_static,
+                )
+            exe = paddle.static.Executor(
+                place=paddle.CUDAPlace(0)
+            )
+            exe.run(sp)
+            out = exe.run(
+                mp,
+                feed={"x": self.np_x, "dout": self.np_dout},
+                fetch_list=[out_static_pg] + out_grads_static_pg,
+            )
+            out_static_baseline, out_grads_static_baseline = out[0], out[1:]
+            for i in range(50):
+                out = exe.run(
+                    mp,
+                    feed={"x": self.np_x, "dout": self.np_dout},
+                    fetch_list=[out_static_pg] + out_grads_static_pg,
+                )
+                out_static, out_grads_static = out[0], out[1:]
+                np.testing.assert_equal(
+                    out_static,
+                    out_static_baseline,
+                    err_msg=(
+                        'Develop: paddle.scale static forward is unstable in %s dtype'
+                    )
+                    % self.dtype,
+                )
+                for idx in range(len(out_grads_static)):
+                    np.testing.assert_equal(
+                        out_grads_static[idx],
+                        out_grads_static_baseline[idx],
+                        err_msg=(
+                            'Develop: paddle.matmul static grad is unstable in %s dtype'
+                        )
+                        % self.dtype,
+                    )
+
+
+class TestScaleDevelopCase1_FP16(TestScaleDevelopCase1_FP32):
+    def init_params(self):
+        self.np_input_dir = "./inputs_case1.npz"
+        self.bias_after_scale = False
+        self.dtype = "float16"
+        self.save_static_res_path = "./static_develop_res_case1_fp16.npz"
+        self.save_eager_res_path = "./eager_develop_res_case1_fp16.npz"
+
+
+class TestScaleDevelopCase1_BFP16(TestScaleDevelopCase1_FP32):
+    def init_params(self):
+        self.np_input_dir = "./inputs_case1.npz"
+        self.bias_after_scale = False
+        self.dtype = "bfloat16"
+        self.save_static_res_path = "./static_develop_res_case1_bfp16.npz"
+        self.save_eager_res_path = "./eager_develop_res_case1_bfp16.npz"
+
+
+class TestScaleDevelopCase2_FP32(TestScaleDevelopCase1_FP32):
+    def init_params(self):
+        self.np_input_dir = "./inputs_case2.npz"
+        self.bias_after_scale = True
+        self.dtype = "float32"
+        self.save_static_res_path = "./static_develop_res_case2_fp32.npz"
+        self.save_eager_res_path = "./eager_develop_res_case2_fp32.npz"
+
+
+class TestScaleDevelopCase2_FP16(TestScaleDevelopCase1_FP32):
+    def init_params(self):
+        self.np_input_dir = "./inputs_case2.npz"
+        self.bias_after_scale = True
+        self.dtype = "float16"
+        self.save_static_res_path = "./static_develop_res_case2_fp16.npz"
+        self.save_eager_res_path = "./eager_develop_res_case2_fp16.npz"
+
+
+class TestScaleDevelopCase2_BFP16(TestScaleDevelopCase1_FP32):
+    def init_params(self):
+        self.np_input_dir = "./inputs_case2.npz"
+        self.bias_after_scale = True
+        self.dtype = "bfloat16"
+        self.save_static_res_path = "./static_develop_res_case2_bfp16.npz"
+        self.save_eager_res_path = "./eager_develop_res_case2_bfp16.npz"
+
+
+if __name__ == '__main__':
+    generate_np_inputs_and_dout()
+    unittest.main()

--- a/test_scale/test_scale_incubate.py
+++ b/test_scale/test_scale_incubate.py
@@ -150,25 +150,31 @@ class TestScaleIncubateCase1_FP32(unittest.TestCase):
         # calculate incubate eager res
         x_eager, scale_eager, bias_eager, dout_eager = self.gen_eager_inputs_and_dout()
         out_eager, out_grads_eager = self.cal_eager_res(x_eager, scale_eager, bias_eager, self.bias_after_scale, dout_eager)
-        out_eager = out_eager.numpy()
-        out_grads_eager = map_structure(
+        del x_eager
+        del scale_eager
+        del bias_eager
+        del dout_eager
+        paddle.device.cuda.empty_cache()
+        out_eager_np = out_eager.numpy()
+        out_grads_eager_np = map_structure(
                                 lambda x: x.numpy(),
                                 out_grads_eager,
                             )
-        
+        del out_eager
+        del out_grads_eager
         # compare incubate eager res with develop eager res
         np.testing.assert_equal(
-            out_eager,
+            out_eager_np,
             out_eager_develop,
             err_msg=(
                 'Incubate: compare scale incubate eager forward res with develop eager forward res failed in %s dtype'
             )
             % self.dtype,
         )
-        for idx in range(len(out_grads_eager)):
+        for idx in range(len(out_grads_eager_np)):
             np.testing.assert_equal(
                 out_grads_eager[idx],
-                out_eager_grads_develop[idx],
+                out_eager_grads_develop,
             err_msg=(
                 'Incubate: compare scale incubate eager grad res with develop eager grad res failed in %s dtype'
             )
@@ -217,7 +223,7 @@ class TestScaleIncubateCase1_FP32(unittest.TestCase):
         for idx in range(len(out_grads_static)):
             np.testing.assert_equal(
                 out_grads_static[idx],
-                out_grads_static_develop[idx],
+                out_grads_static_develop,
             err_msg=(
                 'Incubate: compare scale incubate static grad res with develop static grad res failed in %s dtype'
             )
@@ -227,11 +233,15 @@ class TestScaleIncubateCase1_FP32(unittest.TestCase):
     def test_eager_stability(self):
         x_eager, scale_eager, bias_eager, dout_eager = self.gen_eager_inputs_and_dout()
         out_eager_baseline, out_grads_eager_baseline = self.cal_eager_res(x_eager, scale_eager, bias_eager, self.bias_after_scale, dout_eager)
-        out_eager_baseline = out_eager_baseline.numpy()
-        out_grads_eager_baseline = map_structure(
+        out_eager_baseline_np = out_eager_baseline.numpy()
+        out_grads_eager_baseline_np = map_structure(
                                 lambda x: x.numpy(),
                                 out_grads_eager_baseline,
                             )
+        del out_eager_baseline
+        del out_grads_eager_baseline
+        paddle.device.cuda.empty_cache()
+
         for i in range(50):
             out_eager, out_grads_eager = self.cal_eager_res(x_eager, scale_eager, bias_eager, self.bias_after_scale, dout_eager)
             out_eager = out_eager.numpy()
@@ -241,7 +251,7 @@ class TestScaleIncubateCase1_FP32(unittest.TestCase):
                                 )
             np.testing.assert_equal(
                 out_eager,
-                out_eager_baseline,
+                out_eager_baseline_np,
                 err_msg=(
                     'Develop: paddle.scale eager forward is unstable in %s dtype'
                 )
@@ -250,7 +260,7 @@ class TestScaleIncubateCase1_FP32(unittest.TestCase):
             for idx in range(len(out_grads_eager)):
                 np.testing.assert_equal(
                     out_grads_eager[idx],
-                    out_grads_eager_baseline[idx],
+                    out_grads_eager_baseline_np[idx],
                     err_msg=(
                         'Develop: paddle.scale eager grad is unstable in %s dtype'
                     )
@@ -310,8 +320,8 @@ class TestScaleIncubateCase1_FP16(TestScaleIncubateCase1_FP32):
         self.np_input_dir = "./inputs_case1.npz"
         self.bias_after_scale = False
         self.dtype = "float16"
-        self.save_static_res_path = "./static_develop_res_case1_fp16.npy"
-        self.save_eager_res_path = "./eager_develop_res_case1_fp16.npy"
+        self.save_static_res_path = "./static_develop_res_case1_fp16.npz"
+        self.save_eager_res_path = "./eager_develop_res_case1_fp16.npz"
 
 
 class TestScaleIncubateCase1_BFP16(TestScaleIncubateCase1_FP32):
@@ -319,8 +329,8 @@ class TestScaleIncubateCase1_BFP16(TestScaleIncubateCase1_FP32):
         self.np_input_dir = "./inputs_case1.npz"
         self.bias_after_scale = False
         self.dtype = "bfloat16"
-        self.save_static_res_path = "./static_develop_res_case1_bfp16.npy"
-        self.save_eager_res_path = "./eager_develop_res_case1_bfp16.npy"
+        self.save_static_res_path = "./static_develop_res_case1_bfp16.npz"
+        self.save_eager_res_path = "./eager_develop_res_case1_bfp16.npz"
 
 
 class TestScaleIncubateCase2_FP32(TestScaleIncubateCase1_FP32):
@@ -328,8 +338,8 @@ class TestScaleIncubateCase2_FP32(TestScaleIncubateCase1_FP32):
         self.np_input_dir = "./inputs_case2.npz"
         self.bias_after_scale = True
         self.dtype = "float32"
-        self.save_static_res_path = "./static_develop_res_case2_fp32.npy"
-        self.save_eager_res_path = "./eager_develop_res_case2_fp32.npy"
+        self.save_static_res_path = "./static_develop_res_case2_fp32.npz"
+        self.save_eager_res_path = "./eager_develop_res_case2_fp32.npz"
 
 
 class TestScaleIncubateCase2_FP16(TestScaleIncubateCase1_FP32):
@@ -337,8 +347,8 @@ class TestScaleIncubateCase2_FP16(TestScaleIncubateCase1_FP32):
         self.np_input_dir = "./inputs_case2.npz"
         self.bias_after_scale = True
         self.dtype = "float16"
-        self.save_static_res_path = "./static_develop_res_case2_fp16.npy"
-        self.save_eager_res_path = "./eager_develop_res_case2_fp16.npy"
+        self.save_static_res_path = "./static_develop_res_case2_fp16.npz"
+        self.save_eager_res_path = "./eager_develop_res_case2_fp16.npz"
 
 
 class TestScaleIncubateCase2_BFP16(TestScaleIncubateCase1_FP32):
@@ -346,8 +356,8 @@ class TestScaleIncubateCase2_BFP16(TestScaleIncubateCase1_FP32):
         self.np_input_dir = "./inputs_case2.npz"
         self.bias_after_scale = True
         self.dtype = "bfloat16"
-        self.save_static_res_path = "./static_develop_res_case2_bfp16.npy"
-        self.save_eager_res_path = "./eager_develop_res_case2_bfp16.npy"
+        self.save_static_res_path = "./static_develop_res_case2_bfp16.npz"
+        self.save_eager_res_path = "./eager_develop_res_case2_bfp16.npz"
 
 
 if __name__ == '__main__':

--- a/test_scale/test_scale_incubate.py
+++ b/test_scale/test_scale_incubate.py
@@ -13,7 +13,7 @@ class TestScaleIncubateCase1_FP32(unittest.TestCase):
         self.init_np_inputs_and_dout()
 
     def init_params(self):
-        self.np_input_dir = "./inputss_case1.npz"
+        self.np_input_dir = "./inputs_case1.npz"
         self.bias_after_scale = False
         self.dtype = "float32"
         self.save_static_res_path = "./static_develop_res_case1_fp32.npz"
@@ -97,7 +97,7 @@ class TestScaleIncubateCase1_FP32(unittest.TestCase):
         # get develop eager res
         develop_res_array = np.load(self.save_eager_res_path)
         out_eager_develop = develop_res_array["out_eager"]
-        out_eager_grads_develop = [develop_res_array["out_eager_grad_0"]]
+        out_eager_grads_develop = [develop_res_array["out_grads_eager_0"]]
 
         # calculate incubate eager res
         x_eager, scale_eager, bias_eager, dout_eager = self.gen_eager_inputs_and_dout()
@@ -126,7 +126,7 @@ class TestScaleIncubateCase1_FP32(unittest.TestCase):
         for idx in range(len(out_grads_eager_np)):
             np.testing.assert_equal(
                 out_grads_eager[idx],
-                out_eager_grads_develop,
+                out_eager_grads_develop[idx],
             err_msg=(
                 'Incubate: compare scale incubate eager grad res with develop eager grad res failed in %s dtype'
             )
@@ -151,17 +151,16 @@ class TestScaleIncubateCase1_FP32(unittest.TestCase):
                     self.bias_after_scale,
                     dout_static,
                 )
-        exe = paddle.static.Executor(
-            place=paddle.CUDAPlace(0)
-        )
-        exe.run(sp)
-        out = exe.run(
-            mp,
-            feed={"x": self.np_x, "dout": self.np_dout},
-            fetch_list=[out_static] + out_grads_static,
-        )
-        out_static, out_grads_static = out[0], out[1:]
-        paddle.disable_static()
+            exe = paddle.static.Executor(
+                place=paddle.CUDAPlace(0)
+            )
+            exe.run(sp)
+            out = exe.run(
+                mp,
+                feed={"x": self.np_x, "dout": self.np_dout},
+                fetch_list=[out_static] + out_grads_static,
+            )
+            out_static, out_grads_static = out[0], out[1:]
         
         # compare incubate static res with develop static res
         np.testing.assert_equal(
@@ -175,7 +174,7 @@ class TestScaleIncubateCase1_FP32(unittest.TestCase):
         for idx in range(len(out_grads_static)):
             np.testing.assert_equal(
                 out_grads_static[idx],
-                out_grads_static_develop,
+                out_grads_static_develop[idx],
             err_msg=(
                 'Incubate: compare scale incubate static grad res with develop static grad res failed in %s dtype'
             )

--- a/test_scale/test_scale_incubate.py
+++ b/test_scale/test_scale_incubate.py
@@ -79,6 +79,7 @@ class TestScaleIncubateCase1_FP32(unittest.TestCase):
         )
         if self.dtype == "bfloat16":
             out = paddle.cast(out, dtype="float32")
+            out_grads = map_structure(lambda x: paddle.cast(x, dtype='float32'), out_grads)
         return out, out_grads
 
     def cal_static_res(self, x, scale, bias, bias_after_scale, dout):
@@ -91,6 +92,7 @@ class TestScaleIncubateCase1_FP32(unittest.TestCase):
         )
         if self.dtype == "bfloat16":
             out = paddle.cast(out, dtype="float32")
+            out_grads = map_structure(lambda x: paddle.cast(x, dtype='float32'), out_grads)
         return out, out_grads
 
     def test_eager_accuracy(self):
@@ -125,7 +127,7 @@ class TestScaleIncubateCase1_FP32(unittest.TestCase):
         )
         for idx in range(len(out_grads_eager_np)):
             np.testing.assert_equal(
-                out_grads_eager[idx],
+                out_grads_eager_np[idx],
                 out_eager_grads_develop[idx],
             err_msg=(
                 'Incubate: compare scale incubate eager grad res with develop eager grad res failed in %s dtype'

--- a/test_scale/test_scale_incubate.py
+++ b/test_scale/test_scale_incubate.py
@@ -1,0 +1,354 @@
+import numpy as np
+import paddle
+import torch
+import unittest
+from paddle.fluid.layers.utils import map_structure
+import sys
+sys.path.append("..")
+from utils import TOLERANCE, convert_dtype_to_torch_type
+
+class TestScaleIncubateCase1_FP32(unittest.TestCase):
+    def setUp(self):
+        self.init_params()
+        self.init_threshold()
+        self.init_np_inputs_and_dout()
+        x_torch, scale_torch, bias_torch, dout_torch = self.gen_torch_inputs_and_dout()
+        out_torch, out_grads_torch = self.cal_torch_res(x_torch, scale_torch, bias_torch, self.bias_after_scale, dout_torch)
+        del x_torch 
+        del scale_torch
+        del bias_torch
+        del dout_torch 
+        self.out_torch = out_torch.cpu().detach().numpy()
+        self.out_grads_torch = map_structure(
+                                lambda x: x.cpu().numpy(),
+                                out_grads_torch,
+                            )
+        del out_torch, out_grads_torch
+        torch.cuda.empty_cache()
+
+    def init_params(self):
+        self.np_input_dir = "./inputss_case1.npz"
+        self.bias_after_scale = False
+        self.dtype = "float32"
+        self.save_static_res_path = "./static_develop_res_case1_fp32.npz"
+        self.save_eager_res_path = "./eager_develop_res_case1_fp32.npz"
+    
+    def init_threshold(self):
+        self.atol = TOLERANCE[self.dtype]["atol"]
+        self.rtol = TOLERANCE[self.dtype]["rtol"]
+
+    def init_np_inputs_and_dout(self):
+        np_inputs_array = np.load(self.np_input_dir)
+        # get np array from npz file
+        self.np_x = np_inputs_array["x"]
+        self.np_scale = np_inputs_array["scale"]
+        self.np_bias = np_inputs_array["bias"]
+        self.np_dout = np_inputs_array["dout"]
+        # convert np array dtype
+        if self.dtype == "float16":
+            self.np_x = self.np_x.astype("float16")
+            self.np_dout = self.np_dout.astype("float16")
+    
+    def gen_torch_inputs_and_dout(self):
+        x_torch = torch.tensor(
+            self.np_x,
+            device='cuda',
+            dtype=convert_dtype_to_torch_type(self.dtype)
+            if self.dtype != 'bfloat16'
+            else torch.float32,
+            requires_grad=True,
+        )
+        scale_torch = self.np_scale
+        bias_torch = self.np_bias
+        dout_torch = torch.tensor(
+            self.np_dout,
+            device='cuda',
+            dtype=convert_dtype_to_torch_type(self.dtype)
+            if self.dtype != 'bfloat16'
+            else torch.float32,
+            requires_grad=True,
+        )
+        return x_torch, scale_torch, bias_torch, dout_torch
+    
+    def gen_eager_inputs_and_dout(self):
+        x_eager = paddle.to_tensor(
+            self.np_x,
+            dtype=self.dtype if self.dtype != 'bfloat16' else "float32",
+            place="gpu",
+        )
+        x_eager.stop_gradient = False
+        scale_eager = self.np_scale
+        bias_eager = self.np_bias
+        dout_eager = paddle.to_tensor(
+            self.np_dout,
+            dtype=self.dtype if self.dtype != 'bfloat16' else "float32",
+            place="gpu",
+        )
+        dout_eager.stop_gradient = False
+        return x_eager, scale_eager, bias_eager, dout_eager
+
+    def gen_static_inputs_and_dout(self):
+        x_static = paddle.static.data(
+            'x',
+            shape=self.np_x.shape,
+            dtype=self.dtype if self.dtype != "bfloat16" else "float32",
+        )
+        x_static.stop_gradient = False
+        scale_static = self.np_scale
+        bias_static = self.np_bias
+        dout_static = paddle.static.data(
+            'dout',
+            shape=self.np_dout.shape,
+            dtype=self.dtype if self.dtype != "bfloat16" else "float32",
+        )
+        dout_static.stop_gradient = False
+        return x_static, scale_static, bias_static, dout_static
+
+    def cal_torch_res(self, x, scale, bias, bias_after_scale, dout):
+        if self.dtype == "bfloat16":
+            x = x.to(dtype=torch.bfloat16)
+            dout = dout.to(dtype=torch.bfloat16)
+        if bias_after_scale:
+            out = x * scale + bias
+        else:
+            out = scale * (x + bias)
+        out_grads = torch.autograd.grad([out], [x], grad_outputs=[dout])
+        if self.dtype == "bfloat16":
+            out = out.to(dtype=torch.float32)
+        return out, out_grads
+
+    def cal_eager_res(self, x, scale, bias, bias_after_scale, dout):
+        if self.dtype == "bfloat16":
+            x = paddle.cast(x, dtype="uint16")
+            dout = paddle.cast(dout, dtype="uint16")
+        out = paddle.scale(x, scale, bias, bias_after_scale)
+        out_grads = paddle.grad(
+            [out], [x], grad_outputs=[dout]
+        )
+        if self.dtype == "bfloat16":
+            out = paddle.cast(out, dtype="float32")
+        return out, out_grads
+
+    def cal_static_res(self, x, scale, bias, bias_after_scale, dout):
+        if self.dtype == "bfloat16":
+            x = paddle.cast(x, dtype="uint16")
+            dout = paddle.cast(dout, dtype="uint16")
+        out = paddle.scale(x, scale, bias, bias_after_scale)
+        out_grads = paddle.static.gradients(
+            [out], [x], target_gradients=[dout]
+        )
+        if self.dtype == "bfloat16":
+            out = paddle.cast(out, dtype="float32")
+        return out, out_grads
+
+    def test_eager_accuracy(self):
+        # get develop eager res
+        develop_res_array = np.load(self.save_eager_res_path)
+        out_eager_develop = develop_res_array["out_eager"]
+        out_eager_grads_develop = [develop_res_array["out_eager_grad_0"]]
+
+        # calculate incubate eager res
+        x_eager, scale_eager, bias_eager, dout_eager = self.gen_eager_inputs_and_dout()
+        out_eager, out_grads_eager = self.cal_eager_res(x_eager, scale_eager, bias_eager, self.bias_after_scale, dout_eager)
+        out_eager = out_eager.numpy()
+        out_grads_eager = map_structure(
+                                lambda x: x.numpy(),
+                                out_grads_eager,
+                            )
+        
+        # compare incubate eager res with develop eager res
+        np.testing.assert_equal(
+            out_eager,
+            out_eager_develop,
+            err_msg=(
+                'Incubate: compare scale incubate eager forward res with develop eager forward res failed in %s dtype'
+            )
+            % self.dtype,
+        )
+        for idx in range(len(out_grads_eager)):
+            np.testing.assert_equal(
+                out_grads_eager[idx],
+                out_eager_grads_develop[idx],
+            err_msg=(
+                'Incubate: compare scale incubate eager grad res with develop eager grad res failed in %s dtype'
+            )
+                % self.dtype,
+            )
+    
+    def test_static_accuracy(self):
+        # get develop static res
+        develop_res_array = np.load(self.save_static_res_path)
+        out_static_develop = develop_res_array["out_static"]
+        out_grads_static_develop = [develop_res_array["out_grads_static_0"]]
+
+        # calculate incubate static res
+        with paddle.fluid.framework._dygraph_guard(None):
+            mp, sp = paddle.static.Program(), paddle.static.Program()
+            with paddle.static.program_guard(mp, sp):
+                x_static, scale_static, bias_static, dout_static = self.gen_static_inputs_and_dout()
+                (out_static, out_grads_static) = self.cal_static_res(
+                    x_static,
+                    scale_static,
+                    bias_static,
+                    self.bias_after_scale,
+                    dout_static,
+                )
+        exe = paddle.static.Executor(
+            place=paddle.CUDAPlace(0)
+        )
+        exe.run(sp)
+        out = exe.run(
+            mp,
+            feed={"x": self.np_x, "dout": self.np_dout},
+            fetch_list=[out_static] + out_grads_static,
+        )
+        out_static, out_grads_static = out[0], out[1:]
+        paddle.disable_static()
+        
+        # compare incubate static res with develop static res
+        np.testing.assert_equal(
+            out_static,
+            out_static_develop,
+            err_msg=(
+                'Incubate: compare scale incubate static forward res with develop static forward res failed in %s dtype'
+            )
+            % self.dtype,
+        )
+        for idx in range(len(out_grads_static)):
+            np.testing.assert_equal(
+                out_grads_static[idx],
+                out_grads_static_develop[idx],
+            err_msg=(
+                'Incubate: compare scale incubate static grad res with develop static grad res failed in %s dtype'
+            )
+                % self.dtype,
+            )
+
+    def test_eager_stability(self):
+        x_eager, scale_eager, bias_eager, dout_eager = self.gen_eager_inputs_and_dout()
+        out_eager_baseline, out_grads_eager_baseline = self.cal_eager_res(x_eager, scale_eager, bias_eager, self.bias_after_scale, dout_eager)
+        out_eager_baseline = out_eager_baseline.numpy()
+        out_grads_eager_baseline = map_structure(
+                                lambda x: x.numpy(),
+                                out_grads_eager_baseline,
+                            )
+        for i in range(50):
+            out_eager, out_grads_eager = self.cal_eager_res(x_eager, scale_eager, bias_eager, self.bias_after_scale, dout_eager)
+            out_eager = out_eager.numpy()
+            out_grads_eager = map_structure(
+                                    lambda x: x.numpy(),
+                                    out_grads_eager,
+                                )
+            np.testing.assert_equal(
+                out_eager,
+                out_eager_baseline,
+                err_msg=(
+                    'Develop: paddle.scale eager forward is unstable in %s dtype'
+                )
+                % self.dtype,
+            )
+            for idx in range(len(out_grads_eager)):
+                np.testing.assert_equal(
+                    out_grads_eager[idx],
+                    out_grads_eager_baseline[idx],
+                    err_msg=(
+                        'Develop: paddle.scale eager grad is unstable in %s dtype'
+                    )
+                    % self.dtype,
+                )
+
+    def test_static_stability(self):
+        with paddle.fluid.framework._dygraph_guard(None):
+            mp, sp = paddle.static.Program(), paddle.static.Program()
+            with paddle.static.program_guard(mp, sp):
+                x_static, scale_static, bias_static, dout_static = self.gen_static_inputs_and_dout()
+                (out_static_pg, out_grads_static_pg) = self.cal_static_res(
+                    x_static,
+                    scale_static,
+                    bias_static,
+                    self.bias_after_scale,
+                    dout_static,
+                )
+            exe = paddle.static.Executor(
+                place=paddle.CUDAPlace(0)
+            )
+            exe.run(sp)
+            out = exe.run(
+                mp,
+                feed={"x": self.np_x, "dout": self.np_dout},
+                fetch_list=[out_static_pg] + out_grads_static_pg,
+            )
+            out_static_baseline, out_grads_static_baseline = out[0], out[1:]
+            for i in range(50):
+                out = exe.run(
+                    mp,
+                    feed={"x": self.np_x, "dout": self.np_dout},
+                    fetch_list=[out_static_pg] + out_grads_static_pg,
+                )
+                out_static, out_grads_static = out[0], out[1:]
+                np.testing.assert_equal(
+                    out_static,
+                    out_static_baseline,
+                    err_msg=(
+                        'Develop: paddle.scale static forward is unstable in %s dtype'
+                    )
+                    % self.dtype,
+                )
+                for idx in range(len(out_grads_static)):
+                    np.testing.assert_equal(
+                        out_grads_static[idx],
+                        out_grads_static_baseline[idx],
+                        err_msg=(
+                            'Develop: paddle.scale static grad is unstable in %s dtype'
+                        )
+                        % self.dtype,
+                    )
+
+
+class TestScaleIncubateCase1_FP16(TestScaleIncubateCase1_FP32):
+    def init_params(self):
+        self.np_input_dir = "./inputs_case1.npz"
+        self.bias_after_scale = False
+        self.dtype = "float16"
+        self.save_static_res_path = "./static_develop_res_case1_fp16.npy"
+        self.save_eager_res_path = "./eager_develop_res_case1_fp16.npy"
+
+
+class TestScaleIncubateCase1_BFP16(TestScaleIncubateCase1_FP32):
+    def init_params(self):
+        self.np_input_dir = "./inputs_case1.npz"
+        self.bias_after_scale = False
+        self.dtype = "bfloat16"
+        self.save_static_res_path = "./static_develop_res_case1_bfp16.npy"
+        self.save_eager_res_path = "./eager_develop_res_case1_bfp16.npy"
+
+
+class TestScaleIncubateCase2_FP32(TestScaleIncubateCase1_FP32):
+    def init_params(self):
+        self.np_input_dir = "./inputs_case2.npz"
+        self.bias_after_scale = True
+        self.dtype = "float32"
+        self.save_static_res_path = "./static_develop_res_case2_fp32.npy"
+        self.save_eager_res_path = "./eager_develop_res_case2_fp32.npy"
+
+
+class TestScaleIncubateCase2_FP16(TestScaleIncubateCase1_FP32):
+    def init_params(self):
+        self.np_input_dir = "./inputs_case2.npz"
+        self.bias_after_scale = True
+        self.dtype = "float16"
+        self.save_static_res_path = "./static_develop_res_case2_fp16.npy"
+        self.save_eager_res_path = "./eager_develop_res_case2_fp16.npy"
+
+
+class TestScaleIncubateCase2_BFP16(TestScaleIncubateCase1_FP32):
+    def init_params(self):
+        self.np_input_dir = "./inputs_case2.npz"
+        self.bias_after_scale = True
+        self.dtype = "bfloat16"
+        self.save_static_res_path = "./static_develop_res_case2_bfp16.npy"
+        self.save_eager_res_path = "./eager_develop_res_case2_bfp16.npy"
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test_scale/test_scale_incubate.py
+++ b/test_scale/test_scale_incubate.py
@@ -27,8 +27,8 @@ class TestScaleIncubateCase1_FP32(unittest.TestCase):
         np_inputs_array = np.load(self.np_input_dir)
         # get np array from npz file
         self.np_x = np_inputs_array["x"]
-        self.np_scale = np_inputs_array["scale"]
-        self.np_bias = np_inputs_array["bias"]
+        self.np_scale = float(np_inputs_array["scale"])
+        self.np_bias = float(np_inputs_array["bias"])
         self.np_dout = np_inputs_array["dout"]
         # convert np array dtype
         if self.dtype == "float16":

--- a/utils.py
+++ b/utils.py
@@ -1,5 +1,3 @@
-import torch
-
 TOLERANCE = {
     "float32": {"atol": 1e-6, "rtol": 1e-6},
     "float16": {"atol": 1e-4, "rtol": 1e-4},
@@ -7,6 +5,8 @@ TOLERANCE = {
 }
 
 def convert_dtype_to_torch_type(dtype):
+    import torch
+
     if dtype == 'float32':
         return torch.float32
     elif dtype == 'float16':


### PR DESCRIPTION
**测试结果**
`test_scale_develop.py`测试用例通过数：20/24，失败用例均为case 1的float16、bfloat16误差超过阈值导致。
`test_scale_incubate.py`测试用例通过数：16/24，失败用例均与float16、bfloat16相关。看起来incubate分支的计算结果与torch更为接近，而与develop分支不同。

**PR改动**
1. 新增`paddle.scale`测试脚本2项；
2. 将`utils.py`中对`torch`的加载延迟到`convert_dtype_to_torch_type`函数体中，这样做的好处是在未安装PyTorch的环境中仍可以执行`test_scale_incubate.py`（该项测试不涉及PyTorch）。