### PR TITLE
Add parallel_cross_entropy multi cards test

### DIFF
--- a/test_parallel_cross_entropy/README.md
+++ b/test_parallel_cross_entropy/README.md
@@ -1,0 +1,8 @@
+## 运行方法
+```
+# develop（这里card_num指的是运行的卡数，只能是2或4或8, develop必须在incubate之前运行）
+$ bash test_parallel_cross_entropy.sh card_num develop
+# incubate（这里card_num指的是对比的develop运行的卡数，只能是2或4或8）
+# 首先修改test_paddle_incubate.py中的word_size为card_num数(2或4或8)
+$ bash test_parallel_cross_entropy.sh card_num incubate
+```

--- a/test_parallel_cross_entropy/get_and_test_paddle_result.py
+++ b/test_parallel_cross_entropy/get_and_test_paddle_result.py
@@ -1,0 +1,353 @@
+import numpy as np
+import paddle
+import paddle.distributed as paddle_dist
+import paddle.distributed.fleet as fleet
+import init_config_class
+import random
+import sys
+sys.path.append("..")
+from utils import TOLERANCE, convert_dtype_to_torch_type
+
+def set_random_seed(seed):
+    """Set random seed for reproducability."""
+    random.seed(seed)
+    np.random.seed(seed)
+    paddle.seed(seed)
+    fleet.meta_parallel.model_parallel_random_seed(seed)
+
+class TestPaddle(init_config_class.InitConfigClass):
+    def __init__(self, group, np_input_dir="./inputs_case1.npz", dtype="float32", save_static_res_path="./static_develop_res_case1_float32.npz" , save_eager_res_path="./eager_develop_res_case1_float32.npz", torch_dir="1_torch_out_float32.npz"):
+        self._init_params(np_input_dir, dtype, save_static_res_path, save_eager_res_path)
+        self._init_threshold()
+        self._init_np_inputs_and_dout()
+        self._group = group
+        world_size = paddle.distributed.get_world_size()
+        rank = paddle.distributed.get_rank()
+        self.np_paddle_logits = np.array_split(self.np_logits, world_size, axis = 1)[rank]
+        if rank == 0:
+            np_inputs_array = np.load(torch_dir)
+            self._out_torch = np_inputs_array["torch_out"]
+            self._out_grads_torch = np.array_split(np_inputs_array["torch_out_grad"], world_size, axis = 1)[rank]
+        
+    
+    def _gen_eager_inputs_and_dout(self):
+        place = paddle.device.get_device()
+        logits_eager = paddle.to_tensor(
+            self.np_paddle_logits,
+            dtype=self.dtype if self.dtype != 'bfloat16' else "float32",
+            place=place,
+        )
+        logits_eager.stop_gradient = False
+        label_eager = paddle.to_tensor(
+            self.np_label,
+            dtype="int64",
+            place=place,
+        )
+        dout_eager = paddle.to_tensor(
+            self.np_dout,
+            dtype=self.dtype if self.dtype != 'bfloat16' else "float32",
+            place=place,
+        )
+        return logits_eager, label_eager, dout_eager
+
+    def _gen_static_inputs_and_dout(self):
+        logits_static = paddle.static.data(
+            'logits',
+            shape=self.np_paddle_logits.shape,
+            dtype=self.dtype if self.dtype != "bfloat16" else "float32",
+        )
+        logits_static.stop_gradient = False
+        label_static = paddle.static.data(
+            'label',
+            shape=self.np_label.shape,
+            dtype="int64",
+        )
+        dout_static = paddle.static.data(
+            'dout',
+            shape=self.np_dout.shape,
+            dtype=self.dtype if self.dtype != "bfloat16" else "float32",
+        )
+        return logits_static, label_static, dout_static
+
+    def _cal_eager_res(self, logits, label, dout):
+        logits_t = logits
+        label_t = label
+        dout_t = dout
+        if self.dtype == "bfloat16":
+            logits_t = paddle.cast(logits, dtype="uint16")
+            dout_t = paddle.cast(dout, dtype="uint16")
+        
+        loss_func = fleet.meta_parallel.ParallelCrossEntropy(mp_group=self._group, ignore_index=-100)
+        out = loss_func(logits_t, label_t)
+
+        out_grads = paddle.grad(
+            [out], [logits_t], grad_outputs=[dout_t]
+        )
+
+        if self.dtype == "bfloat16":
+            out = paddle.cast(out, dtype="float32")
+            out_grads = paddle.cast(out_grads[0], dtype="float32")
+
+        return out, out_grads[0]
+
+    def _cal_static_res(self, logits, label, dout):
+        logits_t = logits
+        label_t = label
+        dout_t = dout
+        if self.dtype == "bfloat16":
+            logits_t = paddle.cast(logits, dtype="uint16")
+            dout_t = paddle.cast(dout, dtype="uint16")
+
+        loss_func = fleet.meta_parallel.ParallelCrossEntropy(mp_group=self._group, ignore_index=-100)
+        out = loss_func(logits_t, label_t)
+        out = paddle.reshape(out, [1])
+        out_grads = paddle.static.gradients(
+            [out], [logits_t], target_gradients=[dout_t]
+        )    
+
+        if self.dtype == "bfloat16":
+            out = paddle.cast(out, dtype="float32")
+            out_grads =  paddle.cast(out_grads[0], dtype="float32")
+        return out, out_grads
+
+    def _test_eager_accuracy(self):
+        logits_eager, label_eager, dout_eager = self._gen_eager_inputs_and_dout()
+        out_eager, out_grads_eager = self._cal_eager_res(logits_eager, label_eager, dout_eager)
+
+        del logits_eager
+        del label_eager 
+        del dout_eager
+        paddle.device.cuda.empty_cache()
+        out_eager1 = paddle.reshape(out_eager, shape = [1])
+        out_eager_np = out_eager1.numpy()
+        out_grads_eager_np = out_grads_eager.numpy()
+
+        del out_eager
+        del out_grads_eager
+        paddle.device.cuda.empty_cache()
+
+        print
+
+        if paddle.distributed.get_rank() == 0:
+
+            np.savez(self._save_eager_res_path, out_eager=out_eager_np, out_grads_eager=out_grads_eager_np)
+
+            # compare eager res with torch
+            try:
+                np.testing.assert_allclose(
+                    out_eager_np,
+                    self._out_torch,
+                    self._atol,
+                    self._rtol,
+                    err_msg=(
+                        'Develop: compare parallel_cross_entropy eager forward res with torch failed in %s dtype'
+                    )
+                    % self.dtype,
+                )
+            except Exception as e:
+                print(e)
+                print("eager_accuracy forward {dtype} failed".format(dtype=self.dtype))
+            
+            try:
+                np.testing.assert_allclose(
+                    out_grads_eager_np,
+                    self._out_grads_torch,
+                    self._atol,
+                    self._rtol,
+                    err_msg=(
+                        'Develop: compare parallel_cross_entropy eager grad res with torch failed in %s dtype'
+                    )
+                    % self.dtype,
+                )
+            except Exception as e:
+                print(e)
+                print("eager_accuracy grad {dtype} failed".format(dtype=self.dtype))
+        
+    def _test_static_accuracy(self):
+        with paddle.fluid.framework._dygraph_guard(None):
+            mp, sp = paddle.static.Program(), paddle.static.Program()
+            with paddle.static.program_guard(mp, sp):
+                logits_eager, label_eager, dout_eager = self._gen_static_inputs_and_dout()
+                (out_static, out_grads_static) = self._cal_static_res(
+                    logits_eager,
+                    label_eager,
+                    dout_eager
+                )
+            exe = paddle.static.Executor()
+            exe.run(sp)
+            out = exe.run(
+                mp,
+                feed={"logits": self.np_paddle_logits,
+                      "label": self.np_label, "dout": self.np_dout},
+                fetch_list=[out_static] + out_grads_static,
+            )
+            out_static, out_grads_static = out[0], out[1:]
+            out_grads_static = out_grads_static[0]
+        
+        if paddle.distributed.get_rank() == 0:
+
+            np.savez(self._save_static_res_path, out_static=out_static, out_grads_static=out_grads_static)
+
+            # compare static res with torch
+            try:
+                np.testing.assert_allclose(
+                    out_static,
+                    self._out_torch,
+                    self._atol,
+                    self._rtol,
+                    err_msg=(
+                        'Develop: compare parallel_cross_entropy static forward res with torch failed in %s dtype'
+                    )
+                    % self.dtype,
+                )
+            except Exception as e:
+                print(e)
+                print("static_accuracy forward {dtype} failed".format(dtype=self.dtype))
+
+            try:
+                np.testing.assert_allclose(
+                    out_grads_static,
+                    self._out_grads_torch,
+                    self._atol,
+                    self._rtol,
+                    err_msg=(
+                        'Develop: compare parallel_cross_entropy static grad res with torch failed in %s dtype'
+                    )
+                    % self.dtype,
+                )
+            except Exception as e:
+                print(e)
+                print("static_accuracy grad {dtype} failed".format(dtype=self.dtype))
+
+
+    def _test_eager_stability(self):
+        logits_eager, label_eager, dout_eager = self._gen_eager_inputs_and_dout()
+        out_eager_baseline, out_grads_eager_baseline = self._cal_eager_res(logits_eager, label_eager, dout_eager)
+        out_eager_baseline_np = out_eager_baseline.numpy()
+        out_grads_eager_baseline_np = out_grads_eager_baseline.numpy()
+        del out_eager_baseline
+        del out_grads_eager_baseline
+        paddle.device.cuda.empty_cache()
+
+        for i in range(50):
+            out_eager, out_grads_eager = self._cal_eager_res(logits_eager, label_eager, dout_eager)
+            out_eager = out_eager.numpy()
+            out_grads_eager = out_grads_eager.numpy()
+                
+            if paddle.distributed.get_rank() == 0:
+                try: 
+                    np.testing.assert_equal(
+                        out_eager,
+                        out_eager_baseline_np,
+                        err_msg=(
+                            'Develop: parallel_cross_entropy eager forward is unstable in %s dtype'
+                        )
+                        % self.dtype,
+                    )
+                except Exception as e:
+                    print(e)
+                    print("eager_stability forward {dtype} failed".format(dtype=self.dtype))
+                
+                try:
+                    np.testing.assert_equal(
+                        out_grads_eager,
+                        out_grads_eager_baseline_np,
+                        err_msg=(
+                            'Develop: parallel_cross_entropy eager grad is unstable in %s dtype'
+                        )
+                        % self.dtype,
+                    )
+                except Exception as e:
+                    print(e)
+                    print("eager_stability grad {dtype} failed".format(dtype=self.dtype))
+
+    def _test_static_stability(self):
+        with paddle.fluid.framework._dygraph_guard(None):
+            mp, sp = paddle.static.Program(), paddle.static.Program()
+            with paddle.static.program_guard(mp, sp):
+                logits_eager, label_eager, dout_eager = self._gen_static_inputs_and_dout()
+                (out_static_pg, out_grads_static_pg) = self._cal_static_res(
+                    logits_eager,
+                    label_eager,
+                    dout_eager,
+                )
+            exe = paddle.static.Executor()
+            exe.run(sp)
+            out = exe.run(
+                mp,
+                feed={"logits": self.np_paddle_logits,
+                      "label": self.np_label, "dout": self.np_dout},
+                fetch_list=[out_static_pg] + out_grads_static_pg,
+            )
+            out_static_baseline, out_grads_static_baseline = out[0], out[1:]
+            
+            for i in range(50):
+                out = exe.run(
+                    mp,
+                    feed={"logits": self.np_paddle_logits,
+                      "label": self.np_label, "dout": self.np_dout},
+                    fetch_list=[out_static_pg] + out_grads_static_pg,
+                )
+                out_static, out_grads_static = out[0], out[1:]
+
+                if paddle.distributed.get_rank() == 0:
+                    try:
+                        np.testing.assert_equal(
+                            out_static,
+                            out_static_baseline,
+                            err_msg=(
+                                'Develop: parallel_cross_entropy static forward is unstable in %s dtype'
+                            )
+                            % self.dtype,
+                        )
+                    except Exception as e:
+                        print(e)
+                        print("static_stability forward {dtype} failed".format(dtype=self.dtype))
+                        
+                    try: 
+                        np.testing.assert_equal(
+                            out_grads_static,
+                            out_grads_static_baseline,
+                            err_msg=(
+                                'Develop: parallel_cross_entropy static grad is unstable in %s dtype'
+                            )
+                            % self.dtype,
+                        )
+                    except Exception as e:
+                        print(e)
+                        print("static_stability forward {dtype} failed".format(dtype=self.dtype))
+
+# dtype_list = ["float32", "float16", "bfloat16"]
+dtype_list = ["float32", "float16"]
+
+dist_strategy = fleet.DistributedStrategy()
+world_size = paddle_dist.get_world_size()
+dist_strategy.hybrid_configs = {
+    "mp_degree": world_size,
+    "pp_degree": 1,
+    "dp_degree": 1,
+}
+paddle_dist.fleet.init(is_collective=True, strategy = dist_strategy)
+
+set_random_seed(1024)
+
+group = paddle_dist.new_group([i for i in range(world_size)], backend='nccl')
+
+for dtype in dtype_list:
+
+    np_input_dir = "./inputs_case1.npz"
+    save_static_res_path = "./static_develop_res_case1_{dtype}.npz".format(dtype=dtype) 
+    save_eager_res_path = "./eager_develop_res_case1_{dtype}.npz".format(dtype=dtype)
+    torch_dir = "./torch_out_{dtype}.npz".format(dtype=dtype)
+
+    test_paddle = TestPaddle(group, np_input_dir, dtype, save_static_res_path, save_eager_res_path, torch_dir)
+    test_paddle._test_eager_accuracy()
+    print("eager {dtype} success".format(dtype=dtype))
+    test_paddle._test_static_accuracy()
+    print("static {dtype} success".format(dtype=dtype))
+    test_paddle._test_eager_stability()
+    print("eager_stability {dtype}  success".format(dtype=dtype))
+    test_paddle._test_static_stability()
+    print("static_stability {dtype}  success".format(dtype=dtype))
+
+    print("{dtype} success".format(dtype=dtype))

--- a/test_parallel_cross_entropy/get_and_test_paddle_result.py
+++ b/test_parallel_cross_entropy/get_and_test_paddle_result.py
@@ -317,8 +317,7 @@ class TestPaddle(init_config_class.InitConfigClass):
                         print(e)
                         print("static_stability forward {dtype} failed".format(dtype=self.dtype))
 
-# dtype_list = ["float32", "float16", "bfloat16"]
-dtype_list = ["float32", "float16"]
+dtype_list = ["float32", "float16", "bfloat16"]
 
 dist_strategy = fleet.DistributedStrategy()
 world_size = paddle_dist.get_world_size()

--- a/test_parallel_cross_entropy/get_torch_result.py
+++ b/test_parallel_cross_entropy/get_torch_result.py
@@ -1,0 +1,79 @@
+import numpy as np
+import torch
+import torch.distributed as torch_dist
+import init_config_class
+import prepare_data
+import sys
+sys.path.append("..")
+from utils import TOLERANCE, convert_dtype_to_torch_type
+
+class TestTorch(init_config_class.InitConfigClass):
+    def __init__(self, device, np_input_dir="./inputs_case1.npz", dtype="float32", torch_dir="1_torch_out_float32.npz"):
+        self._init_params(np_input_dir, dtype)
+        self._init_threshold()
+        self._init_np_inputs_and_dout()
+        self._device = device
+        logits_torch, label_torch, dout_torch = self._gen_torch_inputs_and_dout()
+        out_torch, out_grads_torch = self._cal_torch_res(logits_torch, label_torch, dout_torch)
+        del logits_torch 
+        del label_torch 
+        del dout_torch
+        
+        a = out_torch.cpu().detach().numpy()
+        b = out_grads_torch.cpu().detach().numpy()
+        np.savez(torch_dir, torch_out=a, torch_out_grad=b)
+        del out_torch, out_grads_torch
+        torch.cuda.empty_cache()
+    
+    def _gen_torch_inputs_and_dout(self):
+        logits_torch = torch.tensor(
+            self.np_logits,
+            device='cuda',
+            dtype=convert_dtype_to_torch_type(self.dtype)
+            if self.dtype != 'bfloat16'
+            else torch.float32,
+            requires_grad=True,
+        )
+        label_torch = torch.tensor(
+            self.np_label,
+            device='cuda',
+            dtype=torch.int64,
+            requires_grad=False,
+        )
+        dout_torch = torch.tensor(
+            self.np_dout,
+            device='cuda',
+            dtype=convert_dtype_to_torch_type(self.dtype)
+            if self.dtype != 'bfloat16'
+            else torch.float32,
+            requires_grad=True,
+        )
+        return logits_torch, label_torch, dout_torch
+
+    def _cal_torch_res(self, logits, label, dout):
+        logits_t = logits
+        label_t = label
+        dout_t = dout
+        if self.dtype == "bfloat16":
+            logits_t = logits.to(dtype=torch.bfloat16)
+            dout_t = dout.to(dtype=torch.bfloat16)
+        out = torch.nn.functional.cross_entropy(
+            logits_t, label_t, weight=None, size_average=None, ignore_index=-100, reduce=None, reduction='none', label_smoothing=0.0)
+        out_grads = torch.autograd.grad(
+            [out], [logits_t], grad_outputs=[dout_t])
+        out_grads = out_grads[0]
+        if self.dtype == "bfloat16":
+            out = out.to(dtype=torch.float32)
+            out_grads = out_grads.to(dtype=torch.float32)
+        return out, out_grads
+
+dtype_list = ["float32", "float16", "bfloat16"]
+
+prepare_data.generate_np_inputs_and_dout()
+
+for dtype in dtype_list:
+
+    np_input_dir = "./inputs_case1.npz"
+    torch_dir = "./torch_out_{dtype}.npz".format(dtype=dtype)
+
+    test_torch = TestTorch('cuda', np_input_dir, dtype, torch_dir)

--- a/test_parallel_cross_entropy/init_config_class.py
+++ b/test_parallel_cross_entropy/init_config_class.py
@@ -1,0 +1,31 @@
+import numpy as np
+import sys
+sys.path.append("..")
+from utils import TOLERANCE, convert_dtype_to_torch_type
+
+class InitConfigClass:
+    def __init__(self):
+        self._init_params()
+        self._init_threshold()
+        self._init_np_inputs_and_dout()
+
+    def _init_params(self, np_input_dir="./inputs_case1.npz", dtype="float32", save_static_res_path="./static_develop_res_case1_float32.npz" , save_eager_res_path="./eager_develop_res_case1_float32.npz"):
+        self._np_input_dir = np_input_dir
+        self.dtype = dtype
+        self._save_static_res_path = save_static_res_path
+        self._save_eager_res_path = save_eager_res_path
+
+    def _init_threshold(self):
+        self._atol = TOLERANCE[self.dtype]["atol"]
+        self._rtol = TOLERANCE[self.dtype]["rtol"]
+
+    def _init_np_inputs_and_dout(self):
+        np_inputs_array = np.load(self._np_input_dir)
+        # get np array from npz file
+        self.np_logits = np_inputs_array["logits"]
+        self.np_label = np_inputs_array["label"]
+        self.np_dout = np_inputs_array["dout"]
+        # convert np array dtype
+        if self.dtype == "float16":
+            self.np_logits = self.np_logits.astype("float16")
+            self.np_dout = self.np_dout.astype("float16")

--- a/test_parallel_cross_entropy/prepare_data.py
+++ b/test_parallel_cross_entropy/prepare_data.py
@@ -1,0 +1,9 @@
+import numpy as np
+
+def generate_np_inputs_and_dout():
+    np.random.seed(0)
+    logits = np.random.random(size=[1, 46256]).astype("float32")
+    label = np.random.randint(46256, size=[1]).astype("int64")
+    dout = np.random.random(size=[1]).astype("float32")
+
+    np.savez("./inputs_case1.npz", logits=logits, label=label, dout=dout)

--- a/test_parallel_cross_entropy/test_paddle_incubate.py
+++ b/test_parallel_cross_entropy/test_paddle_incubate.py
@@ -1,0 +1,233 @@
+from utils import TOLERANCE, convert_dtype_to_torch_type
+import numpy as np
+import paddle
+import torch
+import unittest
+from paddle.fluid.layers.utils import map_structure
+import sys
+sys.path.append("..")
+
+world_size = 8
+t_shape = int(46256/world_size)
+
+class TestCrossEntropyLossIncubateCase1_FP32(unittest.TestCase):
+    def setUp(self):
+        self.init_params()
+        self.init_threshold()
+        self.init_np_inputs_and_dout()
+
+    def init_params(self):
+        self.np_input_dir = "./inputs_case1.npz"
+        self.dtype = "float32"
+        self.save_static_res_path = "./static_develop_res_case1_float32.npz"
+        self.save_eager_res_path = "./eager_develop_res_case1_float32.npz"
+
+    def init_threshold(self):
+        self.atol = TOLERANCE[self.dtype]["atol"]
+        self.rtol = TOLERANCE[self.dtype]["rtol"]
+
+    def init_np_inputs_and_dout(self):
+        np_inputs_array = np.load(self.np_input_dir)
+        # get np array from npz file
+        self.np_logits = np_inputs_array["logits"][0]
+        self.np_label = np_inputs_array["label"]
+        self.np_dout = np_inputs_array["dout"]
+        # convert np array dtype
+        if self.dtype == "float16":
+            self.np_logits = self.np_logits.astype("float16")
+            self.np_label = self.np_label.astype("int64")
+            self.np_dout = self.np_dout.astype("float16")
+
+    def gen_eager_inputs_and_dout(self):
+        logits_eager = paddle.to_tensor(
+            self.np_logits,
+            dtype=self.dtype if self.dtype != 'bfloat16' else "float32",
+            place="gpu",
+        )
+        logits_eager.stop_gradient = False
+        lablel_eager = paddle.to_tensor(
+            self.np_label,
+            dtype="int64",
+            place="gpu",
+        )
+        dout_eager = paddle.to_tensor(
+            self.np_dout,
+            dtype=self.dtype if self.dtype != 'bfloat16' else "float32",
+            place="gpu",
+        )
+        return logits_eager, lablel_eager, dout_eager
+
+    def gen_static_inputs_and_dout(self):
+        logits_static = paddle.static.data(
+            'logits',
+            shape=self.np_logits.shape,
+            dtype=self.dtype if self.dtype != "bfloat16" else "float32",
+        )
+        logits_static.stop_gradient = False
+        label_static = paddle.static.data(
+            'label',
+            shape=self.np_label.shape,
+            dtype="int64",
+        )
+        dout_static = paddle.static.data(
+            'dout',
+            shape=self.np_dout.shape,
+            dtype=self.dtype if self.dtype != "bfloat16" else "float32",
+        )
+        return logits_static, label_static, dout_static
+
+    def cal_eager_res(self, logits, label, dout):
+        logits_t = logits
+        label_t = label
+        dout_t = dout
+        if self.dtype == "bfloat16":
+            logits_t = paddle.cast(logits, dtype="uint16")
+            dout_t = paddle.cast(dout, dtype="uint16")
+        out = paddle.nn.functional.softmax_with_cross_entropy(
+            logits_t,
+            label_t,
+            ignore_index=-100,
+            soft_label=False,
+            axis=-1,
+        )
+        out_grads = paddle.grad(
+            [out], [logits_t], grad_outputs=[dout_t]
+        )
+        if self.dtype == "bfloat16":
+            out = paddle.cast(out, dtype="float32")
+        return out, out_grads
+
+    def cal_static_res(self, logits, label, dout):
+        logits_t = logits
+        label_t = label
+        dout_t = dout
+        if self.dtype == "bfloat16":
+            logits_t = paddle.cast(logits, dtype="uint16")
+            dout_t = paddle.cast(dout, dtype="uint16")
+        out = paddle.nn.functional.softmax_with_cross_entropy(
+            logits_t,
+            label_t,
+            ignore_index=-100,
+            soft_label=False,
+            axis=-1,
+        )
+        out_grads = paddle.static.gradients(
+            [out], [logits_t], target_gradients=[dout_t]
+        )
+        if self.dtype == "bfloat16":
+            out = paddle.cast(out, dtype="float32")
+        return out, out_grads
+
+    def test_eager_accuracy(self):
+
+        # get develop eager res
+        develop_res_array = np.load(self.save_eager_res_path)
+        out_eager_develop = develop_res_array["out_eager"]
+        out_eager_grad_0_develop = develop_res_array["out_grads_eager"]
+        out_eager_grads_develop = [out_eager_grad_0_develop]
+
+        logits_eager, label_eager, dout_eager = self.gen_eager_inputs_and_dout()
+        out_eager, out_grads_eager = self.cal_eager_res(
+            logits_eager, label_eager, dout_eager)
+        del logits_eager
+        del label_eager
+        del dout_eager
+        paddle.device.cuda.empty_cache()
+        out_eager_np = out_eager.numpy()
+        out_grads_eager_np = map_structure(
+            lambda x: x.numpy(),
+            out_grads_eager,
+        )
+        del out_eager
+        del out_grads_eager
+        paddle.device.cuda.empty_cache()
+        # compare incubate eager res with develop eager res
+        np.testing.assert_equal(
+            out_eager_np,
+            out_eager_develop,
+            err_msg=(
+                'Incubate: compare cross_entropy incubate eager forward res with develop eager forward res failed in %s dtype'
+            )
+            % self.dtype,
+        )
+        for idx in range(len(out_grads_eager_np)):
+            out_grads_eager_np[idx] = np.array_split(out_grads_eager_np[idx], world_size, axis = 0)[0]
+            out_grads_eager_np[idx] = out_grads_eager_np[idx].reshape((1, t_shape))
+            np.testing.assert_equal(
+                out_grads_eager_np[idx],
+                out_eager_grads_develop[idx],
+                err_msg=(
+                    'Incubate: compare cross_entropy incubate eager grad res with develop eager grad res failed in %s dtype'
+                )
+                % self.dtype,
+            )
+
+    def test_static_accuracy(self):
+        # get develop static res
+        develop_res_array = np.load(self.save_static_res_path)
+        out_static_develop = develop_res_array["out_static"]
+        out_grads_static_0_develop = develop_res_array["out_grads_static"]
+        out_grads_static_develop = [out_grads_static_0_develop]
+
+        # calculate incubate static res
+        with paddle.fluid.framework._dygraph_guard(None):
+            mp, sp = paddle.static.Program(), paddle.static.Program()
+            with paddle.static.program_guard(mp, sp):
+                logits_static, label_static, dout_static = self.gen_static_inputs_and_dout()
+                (out_static, out_grads_static) = self.cal_static_res(
+                    logits_static,
+                    label_static,
+                    dout_static,
+                )
+            exe = paddle.static.Executor(
+                place=paddle.CUDAPlace(0)
+            )
+            exe.run(sp)
+            out = exe.run(
+                mp,
+                feed={"logits": self.np_logits,
+                      "label": self.np_label, "dout": self.np_dout},
+                fetch_list=[out_static] + out_grads_static,
+            )
+            out_static, out_grads_static = out[0], out[1:]
+
+        # compare incubate static res with develop static res
+        np.testing.assert_equal(
+            out_static,
+            out_static_develop,
+            err_msg=(
+                'Incubate: compare cross_entropy incubate static forward res with develop static forward res failed in %s dtype'
+            )
+            % self.dtype,
+        )
+        for idx in range(len(out_grads_static)):
+            out_grads_static[idx] = np.array_split(out_grads_static[idx], world_size, axis = 0)[0]
+            out_grads_static[idx] = out_grads_static[idx].reshape((1, t_shape))
+            np.testing.assert_equal(
+                out_grads_static[idx],
+                out_grads_static_develop[idx],
+                err_msg=(
+                    'Incubate: compare cross_entropy incubate static grad res with develop static grad res failed in %s dtype'
+                )
+                % self.dtype,
+            )
+
+
+class TestCrossEntropyDevelopCase1_FP16(TestCrossEntropyLossIncubateCase1_FP32):
+    def init_params(self):
+        self.np_input_dir = "./inputs_case1.npz"
+        self.dtype = "float16"
+        self.save_static_res_path = "./static_develop_res_case1_float16.npz"
+        self.save_eager_res_path = "./eager_develop_res_case1_float16.npz"
+
+
+# class TestCrossEntropyDevelopCase2_BFP16(TestCrossEntropyLossIncubateCase1_FP32):
+#     def init_params(self):
+#         self.np_input_dir = "./inputs_case1.npz"
+#         self.dtype = "bfloat16"
+#         self.save_static_res_path = "./static_develop_res_case2_bfp16.npz"
+#         self.save_eager_res_path = "./eager_develop_res_case2_bfp16.npz"
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test_parallel_cross_entropy/test_parallel_cross_entropy.sh
+++ b/test_parallel_cross_entropy/test_parallel_cross_entropy.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+set -ex
+
+card_num=$1
+version=$2
+
+case $card_num in 
+    2 ) export CUDA_VISIBLE_DEVICES=0,1 ;;
+    4 ) export CUDA_VISIBLE_DEVICES=0,1,2,3 ;;
+    8 ) export CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 ;;
+    * )  
+        echo '请输入正确的卡数'  
+        exit 
+    ;;
+esac
+
+#please run "bash test_parallel_cross.entropy.sh * develop" first
+
+if [ "$version" == 'develop' ]; then
+    rm -rf *.npz
+    rm -rf log/
+    python get_torch_result.py
+    python -m paddle.distributed.launch get_and_test_paddle_result.py
+elif [ "$version" == 'incubate' ]; then
+    python test_paddle_incubate.py
+else
+   echo "请输入develop或者incubate"
+fi


### PR DESCRIPTION
1.inbubate的稳定性测试跳过，因为API与paddle.nn.CrossEntropyLoss对应的incubate API相同（fluid.layers.softmax_with_cross_entropy），因此incubate API的稳定性测试已经在CrossEntropyLoss测试中被完成，不再重复测试
2.kernel不支持bf16数据类型，运行结果：
![image](https://user-images.githubusercontent.com/71813629/232471796-a850d856-ab77-425e-b3bf-d64e7c1b629b.png)

测试case:
logits shape:[1,46256]
develop测试误差：
正确性误差：
fp16，2卡，动态图，前向运行结果：
![image](https://user-images.githubusercontent.com/71813629/232471934-b342b968-c62f-4002-8457-c9392d944b3d.png)
fp16，2卡，动态图，反向运行结果：
![image](https://user-images.githubusercontent.com/71813629/232472043-a164525e-afd0-426f-b32b-e0b7dca8c395.png)
fp16，2卡，静态图，前向运行结果：
![image](https://user-images.githubusercontent.com/71813629/232472198-943a1836-be57-481c-87d9-9ae1e52dd71c.png)
fp16，2卡，静态图，反向运行结果：
![image](https://user-images.githubusercontent.com/71813629/232472230-a30108e3-2cf5-4969-98b6-6251cf9c5154.png)
fp16，4卡，动态图，前向运行结果：
![image](https://user-images.githubusercontent.com/71813629/232472375-c214fb32-3a7f-4b59-a30a-f5f90dbdd88a.png)
fp16，4卡，静态图，前向运行结果：
![image](https://user-images.githubusercontent.com/71813629/232472474-2826cc17-1d13-4f2a-9d38-e88af863ed44.png)
fp16，8卡，动态图，前向运行结果：
![image](https://user-images.githubusercontent.com/71813629/232472624-ecfc97f5-e924-4ba6-aba3-1dbfed49c8fa.png)
fp16，8卡，静态图，前向运行结果：
![image](https://user-images.githubusercontent.com/71813629/232472708-29454f71-ec13-4fff-9f1e-7295ca8425f7.png)
稳定性误差：
fp32，4卡，动态图，反向稳定性运行结果：
![image](https://user-images.githubusercontent.com/71813629/232472818-cfdfef38-948e-4067-8bdc-8a1809904845.png)
fp32，4卡，静态图，反向稳定性运行结果：
![image](https://user-images.githubusercontent.com/71813629/232472870-cb9a81b2-da20-40d4-93cb-67f4079047ff.png)

incubate测试误差：
正确性误差：
对比2卡测试，fp32，动态图，反向测试结果：
![image](https://user-images.githubusercontent.com/71813629/232473007-ab121825-52bf-4170-911a-dadf91feaa5a.png)
对比2卡测试，fp32，静态图，反向测试结果：
![image](https://user-images.githubusercontent.com/71813629/232473062-a10b2b38-a5e0-4f05-8fa5-e396c6c80855.png)
对比4卡测试，fp32，动态图，反向测试结果：
![image](https://user-images.githubusercontent.com/71813629/232473116-31d24bf3-5ffe-422a-8b21-6146fba03cf8.png)
对比4卡测试，fp32，静态图，反向测试结果：
![image](https://user-images.githubusercontent.com/71813629/232473175-467bb6c7-858e-413f-a617-eee3f022d3b3.png)
对比8卡测试，fp32，动态图，反向测试结果：
![image](https://user-images.githubusercontent.com/71813629/232473244-6230e95e-1ec7-4b5a-939a-4893db498009.png)
对比8卡测试，fp32，静态图，反向测试结果：
![image](https://user-images.githubusercontent.com/71813629/232473383-d6306816-242e-4b5b-aca0-9f9953fdb48e.png)
对比2卡测试，fp16，动态图，前向测试结果：
![image](https://user-images.githubusercontent.com/71813629/232473426-3c62735b-0b40-4190-a6f3-c41a6ebb149b.png)
对比2卡测试，fp16，静态图，前向测试结果：
![image](https://user-images.githubusercontent.com/71813629/232473503-ab025c75-39b9-41fc-9652-f7264cea3f4b.png)
对比4卡测试，fp16，动态图，前向测试结果：
![image](https://user-images.githubusercontent.com/71813629/232473573-c8b95179-90f6-4316-a2ec-944d2b66b588.png)
对比4卡测试，fp16，静态图，前向测试结果：
![image](https://user-images.githubusercontent.com/71813629/232473632-8eacf21f-5b41-4569-90ad-e33750db53e1.png)
对比8卡测试，fp16，动态图，前向测试结果：
![image](https://user-images.githubusercontent.com/71813629/232473684-9cff45c4-88e1-4d48-a54c-cf71dcaea1a8.png)
对比8卡测试，fp16，静态图，前向测试结果：
![image](https://user-images.githubusercontent.com/71813629/232473739-0488b873-e02e-4f1a-8ffb-a62617424571.png)

