### PR TITLE
Change Assert Log For fleet.meta_parallel.VocabParallelEmbedding

### DIFF
--- a/test_vocab_parallel_embedding/README.md
+++ b/test_vocab_parallel_embedding/README.md
@@ -1,7 +1,7 @@
 ## 运行方法
 ```
-# develop（这里card_num指的是运行的卡数，只能是2或4或8, develop必须在incubate之前运行）
-$ bash test_vocab_parallel_embedding.sh card_num develop
-# incubate（这里card_num指的是运行的卡数，只能是2或4或8）
-$ bash test_vocab_parallel_embedding.sh card_num incubate
+# develop（这里card_num指的是运行的卡数，只能是2或4或8, develop必须在incubate之前运行, log_dir为输出log的路径）
+$ bash test_vocab_parallel_embedding.sh card_num develop log_dir
+# incubate（这里card_num指的是运行的卡数，只能是2或4或8，log_dir为输出log的路径
+$ bash test_vocab_parallel_embedding.sh card_num incubate log_dir
 ```

--- a/test_vocab_parallel_embedding/get_torch_result.py
+++ b/test_vocab_parallel_embedding/get_torch_result.py
@@ -5,7 +5,12 @@ import init_config_class
 import prepare_data
 import sys
 sys.path.append("..")
-from utils import TOLERANCE, convert_dtype_to_torch_type
+from utils import (
+    TOLERANCE,
+    convert_dtype_to_torch_type,
+    np_assert_accuracy,
+    np_assert_staility,
+)
 
 class TestTorch(init_config_class.InitConfigClass):
     def __init__(self, device, np_input_dir="", dtype="", torch_dir=""):
@@ -13,15 +18,9 @@ class TestTorch(init_config_class.InitConfigClass):
         self._init_threshold()
         self._init_np_inputs_and_dout()
         self._device = device
-        x_torch, table_torch, dout_torch = self._gen_torch_inputs_and_dout()
-        out_torch, out_grads_torch = self._cal_torch_res(x_torch, table_torch, dout_torch)
-        del x_torch 
-        del table_torch 
-        del dout_torch
+        out_torch, out_grads_torch = self._get_and_compare_torch_result()
         
-        a = out_torch.cpu().detach().numpy()
-        b = out_grads_torch.cpu().detach().numpy()
-        np.savez(torch_dir, torch_out=a, torch_out_grad=b)
+        np.savez(torch_dir, torch_out=out_torch, torch_out_grad=out_grads_torch)
         del out_torch, out_grads_torch
         torch.cuda.empty_cache()
     
@@ -68,6 +67,44 @@ class TestTorch(init_config_class.InitConfigClass):
             out_grads = out_grads.to(dtype=torch.float32)
         
         return out, out_grads
+    
+    def _get_and_compare_torch_result(self):
+        x_torch, table_torch, dout_torch = self._gen_torch_inputs_and_dout()
+        base_out, base_dout = self._cal_torch_res(x_torch, table_torch, dout_torch)
+        base_out_np = base_out.detach().cpu().numpy()
+        base_dout_np = base_dout.detach().cpu().numpy()
+        for i in range(50):
+            x_torch, table_torch, dout_torch = self._gen_torch_inputs_and_dout()
+            out, dout = self._cal_torch_res(x_torch, table_torch, dout_torch)
+            out_np =  out.detach().cpu().numpy()
+            dout_np = dout.detach().cpu().numpy()
+            try:
+                np_assert_staility(
+                    base_out_np,
+                    out_np,
+                    self._dtype,
+                    version="torch",
+                    eager_or_static_mode="eager",
+                    fwd_or_bkd="forward",
+                    api="torch.nn.Embedding",
+                )
+            except Exception as e:
+                print(e)
+                print("torch_stability forward {dtype} failed".format(dtype=self._dtype))
+            try:
+                np_assert_staility(
+                    base_dout_np,
+                    dout_np,
+                    self._dtype,
+                    version="torch",
+                    eager_or_static_mode="eager",
+                    fwd_or_bkd="backward",
+                    api="torch.nn.Embedding",
+                )
+            except Exception as e:
+                print(e)
+                print("torch_stability backward {dtype} failed".format(dtype=self._dtype))
+        return base_out_np, base_dout_np
 
 dtype_list = ["float32", "float16", "bfloat16"]
 

--- a/test_vocab_parallel_embedding/prepare_data.py
+++ b/test_vocab_parallel_embedding/prepare_data.py
@@ -7,7 +7,7 @@ def generate_np_inputs_and_dout():
     dim_2 = init_config_class.dim_2
     dim_3 = init_config_class.dim_3
     x_case1 = np.random.randint(low=0, high=dim_1, size=[1, dim_2]).astype("int64")
-    table_case1 = np.random.random(size=[dim_1, dim_3]).astype("float32")
-    dout_case1 = np.random.random(size=[1, dim_2, dim_3]).astype("float32")
+    table_case1 = np.random.random(size=[dim_1, dim_3]).astype("float32") - 0.5 
+    dout_case1 = np.random.random(size=[1, dim_2, dim_3]).astype("float32") - 0.5
 
     np.savez("./inputs_case1.npz", x = x_case1, table = table_case1, dout = dout_case1)

--- a/test_vocab_parallel_embedding/test_vocab_parallel_embedding.sh
+++ b/test_vocab_parallel_embedding/test_vocab_parallel_embedding.sh
@@ -3,6 +3,9 @@ set -ex
 
 card_num=$1
 version=$2
+log_dir=$3
+
+export NVIDIA_TF32_OVERRIDE=0
 
 case $card_num in 
     2 ) export CUDA_VISIBLE_DEVICES=0,1 ;;
@@ -18,9 +21,8 @@ esac
 
 if [ "$version" == 'develop' ]; then
     rm -rf *.npz
-    rm -rf log/
     python get_torch_result.py
-    python -m paddle.distributed.launch get_and_test_paddle_result.py
+    python -m paddle.distributed.launch --log_dir $log_dir get_and_test_paddle_result.py
 elif [ "$version" == 'incubate' ]; then
     python -m paddle.distributed.launch test_paddle_incubate.py
 else


### PR DESCRIPTION
重测后结果如下：
模型case：
input shape: [1, 4096]
table shape: [28100, 12288] （两卡的输入table）
还原的原始参数：
input shape: [1, 4096]
table shape: [56200, 12288] （未切分的table）
两卡精度误差：
动态图float32稳定性测试的反向：
![image](https://user-images.githubusercontent.com/26091437/233821960-21f49dad-e6db-46a9-9912-9bbc2c5878ec.png)
静态图float32稳定性测试的反向：
![image](https://user-images.githubusercontent.com/26091437/233821963-d013dee1-169a-49e8-8913-05042f3068ba.png)
动态图float16正确性测试的反向：
![image](https://user-images.githubusercontent.com/26091437/233821969-539607ea-98e8-4bab-ba46-d10fd0a316dd.png)
静态图float16正确性测试的反向：
![image](https://user-images.githubusercontent.com/26091437/233821975-8b9bc373-c524-49dc-a675-748b80fb5f87.png)
动态图float16稳定性测试的反向：
![image](https://user-images.githubusercontent.com/26091437/233821985-b9ee2ff9-870c-4403-a8af-d90eeaedf553.png)
静态图float16稳定性测试的反向：
![image](https://user-images.githubusercontent.com/26091437/233821994-77441bd8-eebb-4887-82aa-7ff5491287f8.png)
动态图bfloat16正确性测试的反向：
![image](https://user-images.githubusercontent.com/26091437/233821999-30b86cce-e12a-4b30-812d-b21929b9452f.png)
静态图bfloat16正确性测试反向：
![image](https://user-images.githubusercontent.com/26091437/233822002-59d2fa27-18d4-46df-9f96-9e960363ff53.png)
动态图bfloat16稳定性测试反向：
![image](https://user-images.githubusercontent.com/26091437/233822007-4a8f1f29-b53c-4200-9664-429853f8ede5.png)
静态图bfloat16稳定性测试反向：
![image](https://user-images.githubusercontent.com/26091437/233822009-53e5c36d-3157-41f1-b329-c697adaf09a1.png)
四卡精度误差：
动态图float32稳定性测试反向：
![image](https://user-images.githubusercontent.com/26091437/233822011-69f29d4e-6548-4e2b-86b1-98e0eb88a041.png)
静态图float32稳定性测试反向：
![image](https://user-images.githubusercontent.com/26091437/233822019-c73ed1f6-da1e-4beb-a0d8-3db59e237068.png)
动态图float16正确性测试反向：
![image](https://user-images.githubusercontent.com/26091437/233822022-feb0b396-3432-408b-84c2-48fdaee0a6f3.png)
静态图float16正确性测试反向：
![image](https://user-images.githubusercontent.com/26091437/233822028-ab27ca43-a324-4cf0-a245-c7f956683d68.png)
动态图float16稳定性测试反向：
![image](https://user-images.githubusercontent.com/26091437/233822032-80e7bdd5-6262-4f62-9a83-4b6f3057e479.png)
静态图float16稳定性测试反向：
![image](https://user-images.githubusercontent.com/26091437/233822034-54aecb1a-aeb3-4be0-bf6d-239db5824d5c.png)
动态图bfloat16正确性测试反向：
![image](https://user-images.githubusercontent.com/26091437/233822037-2b670dc2-34d5-4ed6-8292-ad0d5f82ad5f.png)
静态图bfloat16正确性测试反向：
![image](https://user-images.githubusercontent.com/26091437/233822043-34f3d57c-7ffb-44bb-9c2f-47c48c125d64.png)