### PR TITLE
adds the maximum test

### DIFF
--- a/test_maximum/test_maximum_develop.py
+++ b/test_maximum/test_maximum_develop.py
@@ -1,0 +1,426 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+import unittest
+
+import numpy as np
+import torch
+
+import paddle
+from paddle.utils import map_structure
+
+sys.path.append("..")
+from utils import (
+    TOLERANCE,
+    convert_dtype_to_torch_type,
+    np_assert_accuracy,
+    np_assert_staility,
+)
+
+class TestMaximumDevelopCase1_FP32(unittest.TestCase):
+    def setUp(self):
+        self.init_params()
+        self.init_threshold()
+        self.init_np_inputs_and_dout()
+        x_torch, y_torch, dout_torch = self.gen_torch_inputs_and_dout()
+        out_torch, out_grads_torch = self.cal_torch_res(
+            x_torch, y_torch, dout_torch
+        )
+        del x_torch
+        del y_torch
+        del dout_torch
+        self.out_torch = out_torch.cpu().detach().numpy()
+        self.out_grads_torch = map_structure(
+            lambda x: x.cpu().detach().numpy(),
+            out_grads_torch,
+        )
+        del out_torch, out_grads_torch
+        torch.cuda.empty_cache()
+
+    def init_params(self):
+        self.dtype = "float32"
+
+    def init_threshold(self):
+        self.atol = TOLERANCE[self.dtype]["atol"]
+        self.rtol = TOLERANCE[self.dtype]["rtol"]
+
+    def init_np_inputs_and_dout(self):
+        # init np array 
+        self.np_x = np.random.random(size=[1]).astype("float32") - 0.5
+        self.np_y = np.random.random(size=[1]).astype("float32") - 0.5
+        self.np_dout = np.random.random(size=[1]).astype("float32") - 0.5
+        # convert np array dtype
+        if self.dtype == "float16":
+            self.np_x = self.np_x.astype("float16")
+            self.np_y = self.np_y.astype("float16")
+            self.np_dout = self.np_dout.astype("float16")
+
+    def gen_torch_inputs_and_dout(self):
+        x_torch = torch.tensor(
+            self.np_x,
+            device='cuda',
+            dtype=convert_dtype_to_torch_type(self.dtype)
+            if self.dtype != 'bfloat16'
+            else torch.float32,
+            requires_grad=True,
+        )
+        y_torch = torch.tensor(
+            self.np_y,
+            device='cuda',
+            dtype=convert_dtype_to_torch_type(self.dtype)
+            if self.dtype != 'bfloat16'
+            else torch.float32,
+            requires_grad=True,
+        )
+        dout_torch = torch.tensor(
+            self.np_dout,
+            device='cuda',
+            dtype=convert_dtype_to_torch_type(self.dtype)
+            if self.dtype != 'bfloat16'
+            else torch.float32,
+            requires_grad=True,
+        )
+        return x_torch, y_torch, dout_torch
+
+    def gen_eager_inputs_and_dout(self):
+        x_eager = paddle.to_tensor(
+            self.np_x,
+            dtype=self.dtype if self.dtype != 'bfloat16' else "float32",
+            place="gpu",
+        )
+        x_eager.stop_gradient = False
+        y_eager = paddle.to_tensor(
+            self.np_y,
+            dtype=self.dtype if self.dtype != 'bfloat16' else "float32",
+            place="gpu",
+        )
+        y_eager.stop_gradient = False
+        dout_eager = paddle.to_tensor(
+            self.np_dout,
+            dtype=self.dtype if self.dtype != 'bfloat16' else "float32",
+            place="gpu",
+        )
+        dout_eager.stop_gradient = False
+        return x_eager, y_eager, dout_eager
+
+    def gen_static_inputs_and_dout(self):
+        x_static = paddle.static.data(
+            'x',
+            shape=self.np_x.shape,
+            dtype=self.dtype if self.dtype != "bfloat16" else "float32",
+        )
+        x_static.stop_gradient = False
+        y_static = paddle.static.data(
+            'y',
+            shape=self.np_y.shape,
+            dtype=self.dtype if self.dtype != "bfloat16" else "float32",
+        )
+        y_static.stop_gradient = False
+        dout_static = paddle.static.data(
+            'dout',
+            shape=self.np_dout.shape,
+            dtype=self.dtype if self.dtype != "bfloat16" else "float32",
+        )
+        dout_static.stop_gradient = False
+        return x_static, y_static, dout_static
+
+    def cal_torch_res(self, x, y, dout):
+        if self.dtype == "bfloat16":
+            x = x.to(dtype=torch.bfloat16)
+            y = y.to(dtype=torch.bfloat16)
+            dout = dout.to(dtype=torch.bfloat16)
+        out = torch.maximum(x, y)
+        out_grads = torch.autograd.grad([out], [x, y], grad_outputs=[dout])
+        if self.dtype == "bfloat16":
+            out = out.to(dtype=torch.float32)
+            out_grads = map_structure(lambda x: x.to(dtype=torch.float32), out_grads)
+        return out, out_grads
+
+    def cal_eager_res(self, x, y, dout):
+        if self.dtype == "bfloat16":
+            x = paddle.cast(x, dtype="uint16")
+            y = paddle.cast(y, dtype="uint16")
+            dout = paddle.cast(dout, dtype="uint16")
+        out = paddle.maximum(x, y)
+        out_grads = paddle.grad([out], [x, y], grad_outputs=[dout])
+        if self.dtype == "bfloat16":
+            out = paddle.cast(out, dtype="float32")
+            out_grads = map_structure(lambda x: paddle.cast(x, dtype="float32"), out_grads)
+        return out, out_grads
+
+    def cal_static_res(self, x, y, dout):
+        if self.dtype == "bfloat16":
+            x = paddle.cast(x, dtype="uint16")
+            y = paddle.cast(y, dtype="uint16")
+            dout = paddle.cast(dout, dtype="uint16")
+        out = paddle.maximum(x, y)
+        out_grads = paddle.static.gradients(
+            [out], [x, y], target_gradients=[dout]
+        )
+        if self.dtype == "bfloat16":
+            out = paddle.cast(out, dtype="float32")
+            out_grads = map_structure(lambda x: paddle.cast(x, dtype="float32"), out_grads)
+        return out, out_grads
+
+    def test_eager_accuracy(self):
+        x_eager, y_eager, dout_eager = self.gen_eager_inputs_and_dout()
+        out_eager, out_grads_eager = self.cal_eager_res(
+            x_eager, y_eager, dout_eager
+        )
+        del x_eager
+        del y_eager
+        del dout_eager
+        paddle.device.cuda.empty_cache()
+        out_eager_np = out_eager.numpy()
+        out_grads_eager_np = map_structure(
+            lambda x: x.numpy(),
+            out_grads_eager,
+        )
+        del out_eager
+        del out_grads_eager
+        paddle.device.cuda.empty_cache()
+        # compare develop eager forward res with torch
+        np_assert_accuracy(
+            out_eager_np,
+            self.out_torch,
+            self.atol,
+            self.rtol,
+            self.dtype,
+            version_a="paddle_develop",
+            version_b="torch",
+            eager_or_static_mode="eager",
+            fwd_or_bkd="forward",
+            api="paddle.maximum",
+        )
+        # compare develop eager backward res with torch
+        for idx in range(len(out_grads_eager_np)):
+            np_assert_accuracy(
+                out_grads_eager_np[idx],
+                self.out_grads_torch[idx],
+                self.atol,
+                self.rtol,
+                self.dtype,
+                version_a="paddle_develop",
+                version_b="torch",
+                eager_or_static_mode="eager",
+                fwd_or_bkd="backward",
+                api="paddle.maximum",
+            )
+
+    def test_static_accuracy(self):
+        with paddle.fluid.framework._dygraph_guard(None):
+            mp, sp = paddle.static.Program(), paddle.static.Program()
+            with paddle.static.program_guard(mp, sp):
+                (
+                    x_static,
+                    y_static,
+                    dout_static,
+                ) = self.gen_static_inputs_and_dout()
+                (out_static, out_grads_static) = self.cal_static_res(
+                    x_static,
+                    y_static,
+                    dout_static,
+                )
+            exe = paddle.static.Executor(place=paddle.CUDAPlace(0))
+            exe.run(sp)
+            out = exe.run(
+                mp,
+                feed={"x": self.np_x, "y": self.np_y, "dout": self.np_dout},
+                fetch_list=[out_static] + out_grads_static,
+            )
+            out_static, out_grads_static = out[0], out[1:]
+
+        # compare develop static forward res with torch
+        np_assert_accuracy(
+            out_static,
+            self.out_torch,
+            self.atol,
+            self.rtol,
+            self.dtype,
+            version_a="paddle_develop",
+            version_b="torch",
+            eager_or_static_mode="static",
+            fwd_or_bkd="forward",
+            api="paddle.maximum",
+        )
+        # compare develop static backward res with torch
+        for idx in range(len(out_grads_static)):
+            np_assert_accuracy(
+                out_grads_static[idx],
+                self.out_grads_torch[idx],
+                self.atol,
+                self.rtol,
+                self.dtype,
+                version_a="paddle_develop",
+                version_b="torch",
+                eager_or_static_mode="static",
+                fwd_or_bkd="backward",
+                api="paddle.maximum",
+            )
+
+    def test_eager_stability(self):
+        x_eager, y_eager, dout_eager = self.gen_eager_inputs_and_dout()
+        out_eager_baseline, out_grads_eager_baseline = self.cal_eager_res(
+            x_eager, y_eager, dout_eager
+        )
+        out_eager_baseline_np = out_eager_baseline.numpy()
+        out_grads_eager_baseline_np = map_structure(
+            lambda x: x.numpy(),
+            out_grads_eager_baseline,
+        )
+        del out_eager_baseline
+        del out_grads_eager_baseline
+        paddle.device.cuda.empty_cache()
+
+        for i in range(50):
+            out_eager, out_grads_eager = self.cal_eager_res(
+                x_eager, y_eager, dout_eager
+            )
+            out_eager = out_eager.numpy()
+            out_grads_eager = map_structure(
+                lambda x: x.numpy(),
+                out_grads_eager,
+            )
+            # test develop eager forward stability
+            np_assert_staility(
+                out_eager,
+                out_eager_baseline_np,
+                self.dtype,
+                version="paddle_develop",
+                eager_or_static_mode="eager",
+                fwd_or_bkd="forward",
+                api="paddle.maximum",
+            )
+            # test develop eager backward stability
+            for idx in range(len(out_grads_eager)):
+                np_assert_staility(
+                    out_grads_eager[idx],
+                    out_grads_eager_baseline_np[idx],
+                    self.dtype,
+                    version="paddle_develop",
+                    eager_or_static_mode="eager",
+                    fwd_or_bkd="backward",
+                    api="paddle.maximum",
+                )
+
+    def test_static_stability(self):
+        with paddle.fluid.framework._dygraph_guard(None):
+            mp, sp = paddle.static.Program(), paddle.static.Program()
+            with paddle.static.program_guard(mp, sp):
+                (
+                    x_static,
+                    y_static,
+                    dout_static,
+                ) = self.gen_static_inputs_and_dout()
+                (out_static_pg, out_grads_static_pg) = self.cal_static_res(
+                    x_static,
+                    y_static,
+                    dout_static,
+                )
+            exe = paddle.static.Executor(place=paddle.CUDAPlace(0))
+            exe.run(sp)
+            out = exe.run(
+                mp,
+                feed={"x": self.np_x, "y": self.np_y, "dout": self.np_dout},
+                fetch_list=[out_static_pg] + out_grads_static_pg,
+            )
+            out_static_baseline, out_grads_static_baseline = out[0], out[1:]
+            for i in range(50):
+                out = exe.run(
+                    mp,
+                    feed={"x": self.np_x, "y": self.np_y, "dout": self.np_dout},
+                    fetch_list=[out_static_pg] + out_grads_static_pg,
+                )
+                out_static, out_grads_static = out[0], out[1:]
+                # test develop static forward stability
+                np_assert_staility(
+                    out_static,
+                    out_static_baseline,
+                    self.dtype,
+                    version="paddle_develop",
+                    eager_or_static_mode="static",
+                    fwd_or_bkd="forward",
+                    api="paddle.maximum",
+                )
+                # test develop static backward stability
+                for idx in range(len(out_grads_static)):
+                    np_assert_staility(
+                        out_grads_static[idx],
+                        out_grads_static_baseline[idx],
+                        self.dtype,
+                        version="paddle_develop",
+                        eager_or_static_mode="static",
+                        fwd_or_bkd="backward",
+                        api="paddle.maximum",
+                    )
+
+
+class TestMaximumDevelopCase1_FP16(TestMaximumDevelopCase1_FP32):
+    def init_params(self):
+        self.dtype = "float16"
+
+'''
+class TestMaximumDevelopCase1_BFP16(TestMaximumDevelopCase1_FP32):
+    def init_params(self):
+        self.dtype = "bfloat16"
+'''
+
+class TestMaximumDevelopCase2_FP32(TestMaximumDevelopCase1_FP32):
+    def init_np_inputs_and_dout(self):
+        # init np array 
+        self.np_x = np.random.random(size=[1, 16, 4096, 128]).astype("float32") - 0.5
+        self.np_y = np.random.random(size=[1, 16, 4096, 128]).astype("float32") - 0.5
+        self.np_dout = np.random.random(size=[1, 16, 4096, 128]).astype("float32") - 0.5
+        # convert np array dtype
+        if self.dtype == "float16":
+            self.np_x = self.np_x.astype("float16")
+            self.np_y = self.np_y.astype("float16")
+            self.np_dout = self.np_dout.astype("float16")
+
+class TestMaximumDevelopCase2_FP16(TestMaximumDevelopCase2_FP32):
+    def init_params(self):
+        self.dtype = "float16"
+
+'''
+class TestMaximumDevelopCase2_BFP16(TestMaximumDevelopCase2_FP32):
+    def init_params(self):
+        self.dtype = "bfloat16"
+'''
+
+class TestMaximumDevelopCase3_FP32(TestMaximumDevelopCase1_FP32):
+    def init_np_inputs_and_dout(self):
+        # init np array 
+        self.np_x = np.ones(shape=[2]).astype("float32") - 0.5
+        self.np_y = np.ones(shape=[2]).astype("float32") - 0.5
+        self.np_dout = np.ones(shape=[2]).astype("float32") - 0.5
+        # convert np array dtype
+        if self.dtype == "float16":
+            self.np_x = self.np_x.astype("float16")
+            self.np_y = self.np_y.astype("float16")
+            self.np_dout = self.np_dout.astype("float16")
+
+class TestMaximumDevelopCase3_FP16(TestMaximumDevelopCase3_FP32):
+    def init_params(self):
+        self.dtype = "float16"
+
+'''
+class TestMaximumDevelopCase3_BFP16(TestMaximumDevelopCase3_FP32):
+    def init_params(self):
+        self.dtype = "bfloat16"
+'''
+
+if __name__ == '__main__':
+    np.random.seed(2023)
+    unittest.main()


### PR DESCRIPTION
# `paddle.maximum` 测试结论
## 问题 1. `commit-6db6a34` 未提供 `bfloat16` 实现
```
TypeError: The data type of 'x' in elementwise_max must be ['float16', 'float32', 'float64', 'int32', 'int64', 'bool'], but received uint16.
```
本提交中 `bfloat16` 的测试代码注释跳过了。

## 问题 2. 当 `x`与 `y` 数值相等时，反向结果与 PyTorch 不一致
```
AssertionError:
Not equal to tolerance rtol=1e-06, atol=1e-06
paddle.maximum static backward: compare paddle_develop res with torch failed in float32 dtype,
max_atol_idx: 0, paddle_develop_value: 0.0, torch_value: 0.25,
max_rtol_idx: 0, paddle_develop_value: 0.0, torch_value: 0.25,

Mismatched elements: 2 / 2 (100%)
Max absolute difference: 0.25
Max relative difference: 1.
 x: array([0., 0.], dtype=float32)
 y: array([0.25, 0.25], dtype=float32)
```